### PR TITLE
Remove generated CRDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ vendor/
 .DS_Store
 bin/
 tmp/
+crds/
 
 # Vscode files
 .vscode

--- a/apis/generate.go
+++ b/apis/generate.go
@@ -20,10 +20,10 @@ limitations under the License.
 // https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 
 // Remove existing CRDs
-//go:generate rm -rf ../cluster/charts/oam-kubernetes-runtime/crds
+//go:generate rm -rf ../crds
 
 // Generate deepcopy methodsets and CRD manifests
-//go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile=../hack/boilerplate.go.txt paths=./... crd:trivialVersions=true output:artifacts:config=../cluster/charts/oam-kubernetes-runtime/crds
+//go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile=../hack/boilerplate.go.txt paths=./... crd:trivialVersions=true output:artifacts:config=../crds
 
 package apis
 


### PR DESCRIPTION
As a library, oam-kubernetes-runtime should not generate its own CRDs. Consumers of the library should generate and install the CRDs from the types defined in the library. See https://github.com/crossplane/crossplane/pull/1436 for more information.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>