### PR TITLE
Allow trait metadata name to be nil

### DIFF
--- a/pkg/controller/oam/applicationconfiguration/render.go
+++ b/pkg/controller/oam/applicationconfiguration/render.go
@@ -102,6 +102,11 @@ func (r *components) Render(ctx context.Context, ac *v1alpha2.ApplicationConfigu
 				return nil, errors.Wrapf(err, errFmtRenderTrait, acc.ComponentName)
 			}
 
+			// Set metadata name for `Trait` if the metadata name is NOT set.
+			if t.GetName() == "" {
+				t.SetName(acc.ComponentName)
+			}
+
 			t.SetOwnerReferences([]metav1.OwnerReference{*ref})
 			t.SetNamespace(ac.GetNamespace())
 

--- a/pkg/controller/oam/applicationconfiguration/render_test.go
+++ b/pkg/controller/oam/applicationconfiguration/render_test.go
@@ -479,8 +479,8 @@ func TestRenderTraitWithoutMetadataName(t *testing.T) {
 		ac  *v1alpha2.ApplicationConfiguration
 	}
 	type want struct {
-		w   []Workload
-		err error
+		w []Workload
+		// err error
 	}
 	cases := map[string]struct {
 		reason string
@@ -534,8 +534,8 @@ func TestRenderTraitWithoutMetadataName(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			r := &components{tc.fields.client, tc.fields.params, tc.fields.workload, tc.fields.trait}
 			got, _ := r.Render(tc.args.ctx, tc.args.ac)
-			if got == nil || got[0].Traits[0].GetName() != componentName {
-				t.Errorf("\n%s\nr.Render(...): -want error, +got error:\n%s\n", tc.reason, "Trait name is NOT" +
+			if len(got) == 0 || len(got[0].Traits) == 0 || got[0].Traits[0].GetName() != componentName {
+				t.Errorf("\n%s\nr.Render(...): -want error, +got error:\n%s\n", tc.reason, "Trait name is NOT"+
 					"automatically set.")
 			}
 		})


### PR DESCRIPTION
implement TODO(negz): This name can be omitted and generated
automatically if each trait kind may apply only once to a
component/workload.

Fix #36 