### PR TITLE
Only patch `spec.workloadRef` to proper trait

### DIFF
--- a/pkg/controller/oam/applicationconfiguration/apply.go
+++ b/pkg/controller/oam/applicationconfiguration/apply.go
@@ -66,10 +66,13 @@ func (a *workloads) Apply(ctx context.Context, w []Workload, ao ...resource.Appl
 				Name:       wl.Workload.GetName(),
 			}
 			// TODO(rz): Need to find a way to make sure that this is compatible with the trait structure.
-			for k, _ := range t.UnstructuredContent()["spec"].(map[string]interface {}) {
-				if k == "workloadRef" {
-					if err := fieldpath.Pave(t.UnstructuredContent()).SetValue("spec.workloadRef", ref); err != nil {
-						return errors.Wrapf(err, errFmtSetWorkloadRef, t.GetName(), wl.Workload.GetName())
+			spec, ok := t.UnstructuredContent()["spec"].(map[string]interface{})
+			if ok {
+				for k := range spec {
+					if k == "workloadRef" {
+						if err := fieldpath.Pave(t.UnstructuredContent()).SetValue("spec.workloadRef", ref); err != nil {
+							return errors.Wrapf(err, errFmtSetWorkloadRef, t.GetName(), wl.Workload.GetName())
+						}
 					}
 				}
 			}

--- a/pkg/controller/oam/applicationconfiguration/apply.go
+++ b/pkg/controller/oam/applicationconfiguration/apply.go
@@ -66,8 +66,12 @@ func (a *workloads) Apply(ctx context.Context, w []Workload, ao ...resource.Appl
 				Name:       wl.Workload.GetName(),
 			}
 			// TODO(rz): Need to find a way to make sure that this is compatible with the trait structure.
-			if err := fieldpath.Pave(t.UnstructuredContent()).SetValue("spec.workloadRef", ref); err != nil {
-				return errors.Wrapf(err, errFmtSetWorkloadRef, t.GetName(), wl.Workload.GetName())
+			for k, _ := range t.UnstructuredContent()["spec"].(map[string]interface {}) {
+				if k == "workloadRef" {
+					if err := fieldpath.Pave(t.UnstructuredContent()).SetValue("spec.workloadRef", ref); err != nil {
+						return errors.Wrapf(err, errFmtSetWorkloadRef, t.GetName(), wl.Workload.GetName())
+					}
+				}
 			}
 
 			if err := a.client.Apply(ctx, t, ao...); err != nil {


### PR DESCRIPTION
If a trait with `spec.workloadRef`, the property should
be merged. If without, the perperty should not be set.
Fix #40