### PR TITLE
governance: add OWNERS.md to define maintainers of this repo

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,17 @@
+# OWNERS
+
+This page lists all maintainers for **this** repository. Each repository in the [Crossplane
+organization](https://github.com/crossplane/) will list their repository maintainers in their own
+`OWNERS.md` file.
+
+Please see the Crossplane
+[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md) for governance
+guidelines and responsibilities for the steering committee and maintainers.
+
+## Maintainers
+
+* Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
+* Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))
+* Hongchao Deng <fengjingchao@gmail.com> ([hongchaodeng](https://github.com/hongchaodeng))
+* Sun Jianbo <wonderflow@icloud.com> ([wonderflow](https://github.com/wonderflow))
+* Ryan Zhang ([ryanzhang-oss](https://github.com/ryanzhang-oss))


### PR DESCRIPTION
### Description of your changes

This PR adds an OWNERS.md file that defines the current maintainers of this repository.  The roles and responsibilities of maintainers are defined in Crossplane
[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md).