### PR TITLE
add workloadRefPath to traitDefinition

### DIFF
--- a/design/one-pager-trait-workload-interaction-mechanism.md
+++ b/design/one-pager-trait-workload-interaction-mechanism.md
@@ -2,7 +2,7 @@
 
 * Owner: Ryan Zhang (@ryanzhang-oss)
 * Reviewers: Crossplane Maintainers
-* Status: Draft
+* Status: Implemented
 
 ## Terminology
 
@@ -26,49 +26,49 @@ We will use the following hypothetical OAM application as the baseline to illust
 apiVersion: core.oam.dev/v1alpha2
 kind: WorkloadDefinition
 metadata:
-name: mydbs.standard.oam.dev
-spec:
-definitionRef:
   name: mydbs.standard.oam.dev
+spec:
+  definitionRef:
+    name: mydbs.standard.oam.dev
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: TraitDefinition
 metadata:
-name: manualscalertraits.core.oam.dev
+  name: manualscalertraits.core.oam.dev
 spec:
-definitionRef:
- name: manualscalertraits.core.oam.dev
+  definitionRef:
+    name: manualscalertraits.core.oam.dev
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
 metadata:
-name: example-db
+  name: example-db
 spec:
-workload:
- apiVersion: standard.oam.dev/v1alpha2
- kind: Mydb
- metadata:
-   name: mydb-example
- spec:
-   containers:
-     - name: mysql
-       image: mysql:latest
+  workload:
+    apiVersion: standard.oam.dev/v1alpha2
+    kind: Mydb
+    metadata:
+      name: mydb-example
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:latest
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
 metadata:
-name: example-appconfig
+  name: example-appconfig
 spec:
-components:
- - componentName: example-db      
-   traits:
-     - trait:
-         apiVersion: core.oam.dev/v1alpha2
-         kind: ManualScalerTrait
-         metadata:
-           name:  example-appconfig-trait
-         spec:
-           replicaCount: 3
+  components:
+     - componentName: example-db      
+       traits:
+         - trait:
+             apiVersion: core.oam.dev/v1alpha2
+             kind: ManualScalerTrait
+             metadata:
+               name:  example-appconfig-trait
+             spec:
+               replicaCount: 3
 ```
 
 The problem is two folds
@@ -122,9 +122,23 @@ The overall idea is for the applicationConfiguration controller to fill critical
 in the workload and trait CR it emits. In addition, we will provide a helper library so that
 trait controller developers can locate the resources they need with a simple function call. 
 Here is the list of changes that we propose.
-1. ApplicationConfig controller no longer assumes that all `trait` CRDs contain a "spec
+1. Add an optional field called `oamAware` to the `traitDefinition` schema. The trait owner needs
+ to declare that a trait relies on the OAM trait/workload interaction mechanism in its
+ corresponding `traitDefinition`. In our example, the new trait definition would look like below.  
+     ```yaml
+       apiVersion: core.oam.dev/v1alpha2
+       kind: TraitDefinition
+       metadata:
+         name: manualscalertraits.core.oam.dev
+       spec:
+         oamAware: true
+         definitionRef:
+           name: manualscalertraits.core.oam.dev
+     ```
+2. ApplicationConfig controller no longer assumes that all `trait` CRDs contain a "spec
 .workloadRef" field conforms to the OAM definition. It only fills the workload GVK to a `trait
-` CR if its CRD has a "spec.workloadRef" field defined as below.  
+` CR with "spec.workloadRef" field defined as below if the corresponding `traitDefiniton` is
+ marked as "oamAware".   
      ```yaml
        workloadRef:
          properties:
@@ -140,7 +154,8 @@ Here is the list of changes that we propose.
          - name
          type: object
      ```
-2. Add a `childResourceKinds` field in the  WorkloadDefinition. 
+     
+3. Add a `childResourceKinds` field in the  WorkloadDefinition. 
 Currently, a workloadDefinition is nothing but a shim of a real workload CRD. We propose to add
 an **optional** field called `childResourceKinds` to the schema of the workloadDefinition. We encourage
 workload owners to fill in this field when they register their controllers to the OAM system. 
@@ -161,7 +176,7 @@ deployment and service child resources.
          - apiVersion: v1
            kind: Service      
     ```
-3. OAM runtime will provide a helper library. The library follows the following logic to help a
+4. OAM runtime will provide a helper library. The library follows the following logic to help a
  trait developer locate the resources for the trait to modify.
     1. Get the corresponding `workload` instance from the Kubernetes cluster with the information
      inserted by the application controller in the `trait` CR.
@@ -179,10 +194,10 @@ deployment and service child resources.
 ## Impact to the existing system
 Here are the impacts of this mechanism to the existing OAM components
 - ApplicationConfiguration: This mechanism requires minimum changes in the
- applicationConfiguration controller.
+ applicationConfiguration controller except that it now needs to check if a trait is "oamAware".
 - Workload: This mechanism does not affect workload controller implementation.
 - Trait: This mechanism is optional so all existing trait controller still works. This mechanism
-requires modification to any existing trait that wants to take advantage of
+requires modification to any existing trait and its traitDefintion that wants to take advantage of
 extensibility of OAM. Any trait that only applies to a certain type of workload, such as
  `EtcdBackup` trait, doesn't need to use this mechanism.
 - WorkloadDefinition: workload owners can modify the existing workloadDefinition if needed.

--- a/design/one-pager-trait-workload-interaction-mechanism.md
+++ b/design/one-pager-trait-workload-interaction-mechanism.md
@@ -122,16 +122,18 @@ The overall idea is for the applicationConfiguration controller to fill critical
 in the workload and trait CR it emits. In addition, we will provide a helper library so that
 trait controller developers can locate the resources they need with a simple function call. 
 Here is the list of changes that we propose.
-1. Add an optional field called `oamAware` to the `traitDefinition` schema. The trait owner needs
- to declare that a trait relies on the OAM trait/workload interaction mechanism in its
- corresponding `traitDefinition`. In our example, the new trait definition would look like below.  
+1. Add an optional field called `nativeTrait` to the `traitDefinition` schema. This is for the trait
+ owner to declare that a trait is native to the OAM trait system instead of importing from an
+ existing operator. This field indicates that the trait owner can modify the trait's operator. It
+ implies that the trait relies on the OAM trait/workload interaction mechanism. In our example
+ , the trait definition would look like below.  
      ```yaml
        apiVersion: core.oam.dev/v1alpha2
        kind: TraitDefinition
        metadata:
          name: manualscalertraits.core.oam.dev
        spec:
-         oamAware: true
+         nativeTrait: true
          definitionRef:
            name: manualscalertraits.core.oam.dev
      ```


### PR DESCRIPTION
Finalize the trait/workoad interaction design. We need to rely on the trait owner to signal if we can add the workloadRef field to its CR. It's very hard for appConfig controller to validate otherwise because

1. CRDs (such as all the existing OAM CRDs in crossplane) may not come with a strict validation schema
2. The trait can come with a strict validation webhook (i.e Knative route) that we have no way to know.