### PR TITLE
[Component Versioning] fix saving right status of Component into  ControllerRevision

### DIFF
--- a/pkg/controller/oam/applicationconfiguration/component.go
+++ b/pkg/controller/oam/applicationconfiguration/component.go
@@ -146,6 +146,11 @@ func (c *ComponentHandler) createControllerRevision(mt metav1.Object, obj runtim
 	}
 	nextRevision := curRevision + 1
 	revisionName := ConstructRevisionName(mt.GetName())
+
+	curComp.Status.LatestRevision = &v1alpha2.Revision{
+		Name:     revisionName,
+		Revision: nextRevision,
+	}
 	// set annotation to component
 	revision := appsv1.ControllerRevision{
 		ObjectMeta: metav1.ObjectMeta{
@@ -167,10 +172,6 @@ func (c *ComponentHandler) createControllerRevision(mt metav1.Object, obj runtim
 	if err != nil {
 		c.l.Info(fmt.Sprintf("error create controllerRevision %v", err), "componentName", mt.GetName())
 		return false
-	}
-	curComp.Status.LatestRevision = &v1alpha2.Revision{
-		Name:     revisionName,
-		Revision: nextRevision,
 	}
 	err = c.client.Status().Update(context.Background(), curComp)
 	if err != nil {

--- a/pkg/controller/oam/applicationconfiguration/component_test.go
+++ b/pkg/controller/oam/applicationconfiguration/component_test.go
@@ -87,7 +87,11 @@ func TestComponentHandler(t *testing.T) {
 	assert.Equal(t, 1, len(revisions.Items))
 	assert.Equal(t, true, strings.HasPrefix(revisions.Items[0].Name, "comp1-"))
 	gotComp := revisions.Items[0].Data.Object.(*v1alpha2.Component)
+	// check component's spec saved in corresponding controllerRevision
 	assert.Equal(t, comp.Spec, gotComp.Spec)
+	// check component's status saved in corresponding controllerRevision
+	assert.Equal(t, gotComp.Status.LatestRevision.Name, revisions.Items[0].Name)
+	assert.Equal(t, gotComp.Status.LatestRevision.Revision, revisions.Items[0].Revision)
 	q.Done(item)
 	// ============ Test Create Event End ===================
 
@@ -120,7 +124,11 @@ func TestComponentHandler(t *testing.T) {
 		assert.Equal(t, true, strings.HasPrefix(v.Name, "comp1-"))
 		if v.Revision == 2 {
 			gotComp := v.Data.Object.(*v1alpha2.Component)
+			// check component's spec saved in corresponding controllerRevision
 			assert.Equal(t, comp2.Spec, gotComp.Spec)
+			// check component's status saved in corresponding controllerRevision
+			assert.Equal(t, gotComp.Status.LatestRevision.Name, v.Name)
+			assert.Equal(t, gotComp.Status.LatestRevision.Revision, v.Revision)
 		}
 	}
 	q.Done(item)


### PR DESCRIPTION
**Problem description**

During creating ControllerRevision, the `component.status.latestRevision` being saved into `controllerRevision.data` is from the old component but not the new one. It makes confusing `controllerRevision.data`  that contains the `component.spec` of the current component but `component.status.latestRevision` of the previous one .

**Solution**

Update `component.status` before constructing and creating ControllerRevision. 