### PR TITLE
Add e2e test for dependency engine

### DIFF
--- a/test/e2e-test/appconfig_dependency_test.go
+++ b/test/e2e-test/appconfig_dependency_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam/util"
 )
 
-var _ = Describe("AppconfigDependency", func() {
+var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 	ctx := context.Background()
 	namespace := "appconfig-dependency-test"
 	var ns corev1.Namespace

--- a/test/e2e-test/appconfig_dependency_test.go
+++ b/test/e2e-test/appconfig_dependency_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -15,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam/util"
 )

--- a/test/e2e-test/appconfig_dependency_test.go
+++ b/test/e2e-test/appconfig_dependency_test.go
@@ -1,0 +1,348 @@
+package controllers_test
+
+import (
+	"context"
+	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam/util"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"time"
+)
+
+var _ = Describe("AppconfigDependency", func() {
+	ctx := context.Background()
+	namespace := "appconfig-dependency-test"
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+	BeforeEach(func() {
+		logf.Log.Info("Start to run a test, clean up previous resources")
+		// delete the namespace with all its resources
+		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))).
+			Should(SatisfyAny(BeNil(), &util.NotFoundMatcher{}))
+		logf.Log.Info("make sure all the resources are removed")
+		objectKey := client.ObjectKey{
+			Name: namespace,
+		}
+		res := &corev1.Namespace{}
+		Eventually(
+			// gomega has a bug that can't take nil as the actual input, so has to make it a func
+			func() error {
+				return k8sClient.Get(ctx, objectKey, res)
+			},
+			time.Second*30, time.Millisecond*500).Should(&util.NotFoundMatcher{})
+		// recreate it
+		Eventually(
+			func() error {
+				return k8sClient.Create(ctx, &ns)
+			},
+			time.Second*3, time.Millisecond*300).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+	})
+	AfterEach(func() {
+		logf.Log.Info("Clean up resources")
+		// delete the namespace with all its resources
+		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))).Should(BeNil())
+	})
+
+	It("trait depends on another trait", func() {
+		label := map[string]string{"trait": "trait"}
+		// create a trait definition
+		tdOut := v1alpha2.TraitDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "services",
+				Labels: label,
+			},
+			Spec: v1alpha2.TraitDefinitionSpec{
+				AppliesToWorkloads: []string{
+					"statefulsets.apps",
+				},
+				Reference: v1alpha2.DefinitionReference{
+					Name: "services",
+				},
+			},
+		}
+		logf.Log.Info("Creating trait definition")
+		Expect(k8sClient.Create(ctx, &tdOut)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+		// Create a service trait CR
+		outName := "trait-trait-out"
+		svc := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      outName,
+				Namespace: namespace,
+				Labels:    label,
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: label,
+				Ports: []corev1.ServicePort{
+					{
+						Port:       80,
+						TargetPort: intstr.FromInt(80),
+						Name:       "web",
+						Protocol:   corev1.ProtocolTCP,
+					},
+				},
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+		}
+		// reflect trait gvk from scheme
+		gvks, _, _ := scheme.ObjectKinds(&svc)
+		svc.APIVersion = gvks[0].GroupVersion().String()
+		svc.Kind = gvks[0].Kind
+		// create another trait definition
+		tdIn := v1alpha2.TraitDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "ingresses.networking.k8s.io",
+				Labels: label,
+			},
+			Spec: v1alpha2.TraitDefinitionSpec{
+				AppliesToWorkloads: []string{
+					"statefulsets.apps",
+				},
+				Reference: v1alpha2.DefinitionReference{
+					Name: "ingresses.networking.k8s.io",
+				},
+			},
+		}
+		logf.Log.Info("Creating another trait definition")
+		Expect(k8sClient.Create(ctx, &tdIn)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+		// Create a ingress trait CR
+		inName := "trait-trait-in"
+		ingress := v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      inName,
+				Namespace: namespace,
+				Labels:    label,
+			},
+			Spec: v1beta1.IngressSpec{
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: "depend.oam.com",
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: v1beta1.IngressBackend{
+											ServicePort: intstr.FromInt(80),
+											ServiceName: outName,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		// reflect trait gvk from scheme
+		gvks, _, _ = scheme.ObjectKinds(&ingress)
+		ingress.APIVersion = gvks[0].GroupVersion().String()
+		ingress.Kind = gvks[0].Kind
+		// create a workload definition
+		wd := v1alpha2.WorkloadDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "statefulsets.apps",
+				Labels: label,
+			},
+			Spec: v1alpha2.WorkloadDefinitionSpec{
+				Reference: v1alpha2.DefinitionReference{
+					Name: "statefulsets.apps",
+				},
+			},
+		}
+		logf.Log.Info("Creating workload definition")
+		// For some reason, WorkloadDefinition is created as a Cluster scope object
+		Expect(k8sClient.Create(ctx, &wd)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+		stsName := "trait-trait-wl"
+		wl := appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      stsName,
+				Namespace: namespace,
+				Labels:    label,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				ServiceName: outName,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: label,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: label,
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "nginx",
+								Image: "nginx:1.17",
+								Ports: []corev1.ContainerPort{
+									{
+										ContainerPort: 80,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		// reflect workload gvk from scheme
+		gvks, _, _ = scheme.ObjectKinds(&wl)
+		wl.APIVersion = gvks[0].GroupVersion().String()
+		wl.Kind = gvks[0].Kind
+		// Create a component definition
+		componentName := "component-trait-trait"
+		comp := v1alpha2.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      componentName,
+				Namespace: namespace,
+				Labels:    label,
+			},
+			Spec: v1alpha2.ComponentSpec{
+				Workload: runtime.RawExtension{
+					Object: &wl,
+				},
+			},
+		}
+		logf.Log.Info("Creating component", "Name", comp.Name, "Namespace", comp.Namespace)
+		Expect(k8sClient.Create(ctx, &comp)).Should(BeNil())
+		// Create application configuration
+		appConfigName := "appconfig-trait-trait"
+		appConfig := v1alpha2.ApplicationConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      appConfigName,
+				Namespace: namespace,
+				Labels:    label,
+			},
+			Spec: v1alpha2.ApplicationConfigurationSpec{
+				Components: []v1alpha2.ApplicationConfigurationComponent{
+					{
+						ComponentName: componentName,
+						Traits: []v1alpha2.ComponentTrait{
+							{
+								Trait: runtime.RawExtension{
+									Object: &svc,
+								},
+								DataOutputs: []v1alpha2.DataOutput{
+									{
+										Name:      "test",
+										FieldPath: "spec.externalTrafficPolicy",
+										Conditions: []v1alpha2.ConditionRequirement{
+											{
+												Operator:  "eq",
+												Value:     "Local",
+												FieldPath: "spec.externalTrafficPolicy",
+											},
+										},
+									},
+								},
+							},
+							{
+								Trait: runtime.RawExtension{
+									Object: &ingress,
+								},
+								DataInputs: []v1alpha2.DataInput{
+									{
+										ValueFrom: v1alpha2.DataInputValueFrom{
+											DataOutputName: "test",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		logf.Log.Info("Creating application config", "Name", appConfig.Name, "Namespace", appConfig.Namespace)
+		Expect(k8sClient.Create(ctx, &appConfig)).Should(BeNil())
+		// Verification before satisfying dependency
+		By("Checking that trait which accepts data isn't created yet")
+		ingressKey := client.ObjectKey{
+			Name:      inName,
+			Namespace: namespace,
+		}
+		ingressIn := &v1beta1.Ingress{}
+		logf.Log.Info("Checking on ingress that inputs data", "Key", ingressKey)
+		Eventually(
+			func() error {
+				return k8sClient.Get(ctx, ingressKey, ingressIn)
+			},
+			time.Second*15, time.Millisecond*500).Should(&util.NotFoundMatcher{})
+		By("Checking that trait which provides data is created")
+		svcKey := client.ObjectKey{
+			Name:      outName,
+			Namespace: namespace,
+		}
+		svcOut := &corev1.Service{}
+		logf.Log.Info("Checking on service that outputs data", "Key", svcKey)
+		Eventually(
+			func() error {
+				return k8sClient.Get(ctx, svcKey, svcOut)
+			},
+			time.Second*15, time.Millisecond*500).Should(BeNil())
+		By("Verify the appconfig's dependency is unsatisfied")
+		appconfigKey := client.ObjectKey{
+			Name:      appConfigName,
+			Namespace: namespace,
+		}
+		appconfig := &v1alpha2.ApplicationConfiguration{}
+		unsatisfiedStatus := []v1alpha2.UnstaifiedDependency{
+			{
+				From: v1alpha2.DependencyFromObject{
+					TypedReference: runtimev1alpha1.TypedReference{
+						APIVersion: corev1.SchemeGroupVersion.String(),
+						Name:       outName,
+						Kind:       "Service",
+					},
+					FieldPath: "spec.externalTrafficPolicy",
+				},
+				To: v1alpha2.DependencyToObject{
+					TypedReference: runtimev1alpha1.TypedReference{
+						APIVersion: v1beta1.SchemeGroupVersion.String(),
+						Name:       inName,
+						Kind:       "Ingress",
+					},
+				},
+			},
+		}
+		logf.Log.Info("Checking on appconfig", "Key", appconfigKey)
+		Eventually(
+			func() error {
+				return k8sClient.Get(ctx, appconfigKey, appconfig)
+			},
+			time.Second*15, time.Millisecond*500).Should(BeNil())
+		Expect(appconfig.Status.Dependency.Unsatisfied).Should(Equal(unsatisfiedStatus))
+		// fill value to fieldPath
+		updated := svcOut
+		updated.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+		Expect(k8sClient.Update(ctx, updated)).Should(Succeed())
+		// Verification after satisfying dependency
+		By("Checking that trait which accepts data is created now")
+		logf.Log.Info("Checking on ingress that inputs data", "Key", ingressKey)
+		Eventually(
+			func() error {
+				return k8sClient.Get(ctx, ingressKey, ingressIn)
+			},
+			time.Second*15, time.Millisecond*500).Should(BeNil())
+		By("Verify the appconfig's dependency is satisfied")
+		appconfig = &v1alpha2.ApplicationConfiguration{}
+		logf.Log.Info("Checking on appconfig", "Key", appconfigKey)
+		Eventually(
+			func() error {
+				return k8sClient.Get(ctx, appconfigKey, appconfig)
+			},
+			time.Second*15, time.Millisecond*500).Should(BeNil())
+		Expect(appconfig.Status.Dependency.Unsatisfied).Should(BeNil())
+	})
+})

--- a/test/e2e-test/appconfig_dependency_test.go
+++ b/test/e2e-test/appconfig_dependency_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 				return k8sClient.Get(ctx, inFooKey, inFoo)
 			},
 			time.Second*15, time.Millisecond*500).Should(BeNil())
-		By("Verify the appconfig's dependency is unsatisfied")
+		By("Verify the appconfig's dependency is satisfied")
 		appconfig = &v1alpha2.ApplicationConfiguration{}
 		logf.Log.Info("Checking on appconfig", "Key", appconfigKey)
 		Eventually(

--- a/test/e2e-test/appconfig_dependency_test.go
+++ b/test/e2e-test/appconfig_dependency_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 				return k8sClient.Get(ctx, objectKey, res)
 			},
 			time.Second*30, time.Millisecond*500).Should(&util.NotFoundMatcher{})
-		// recreate it
+		// recreate the namespace for testing
 		Eventually(
 			func() error {
 				return k8sClient.Create(ctx, &ns)

--- a/test/e2e-test/appconfig_dependency_test.go
+++ b/test/e2e-test/appconfig_dependency_test.go
@@ -15,6 +15,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam/util"
 )

--- a/test/e2e-test/appconfig_dependency_test.go
+++ b/test/e2e-test/appconfig_dependency_test.go
@@ -2,31 +2,39 @@ package controllers_test
 
 import (
 	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam/util"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"time"
 )
 
 var _ = Describe("AppconfigDependency", func() {
 	ctx := context.Background()
 	namespace := "appconfig-dependency-test"
-	ns := corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
-		},
-	}
+	var ns corev1.Namespace
+	var wd v1alpha2.WorkloadDefinition
+	var td v1alpha2.TraitDefinition
+	tempFoo := &unstructured.Unstructured{}
+	tempFoo.SetAPIVersion("example.com/v1")
+	tempFoo.SetKind("Foo")
+	tempFoo.SetNamespace(namespace)
 	BeforeEach(func() {
+		ns = corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
 		logf.Log.Info("Start to run a test, clean up previous resources")
 		// delete the namespace with all its resources
 		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))).
@@ -48,160 +56,145 @@ var _ = Describe("AppconfigDependency", func() {
 				return k8sClient.Create(ctx, &ns)
 			},
 			time.Second*3, time.Millisecond*300).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
-	})
-	AfterEach(func() {
-		logf.Log.Info("Clean up resources")
-		// delete the namespace with all its resources
-		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))).Should(BeNil())
-	})
-
-	It("trait depends on another trait", func() {
-		label := map[string]string{"trait": "trait"}
-		// create a trait definition
-		tdOut := v1alpha2.TraitDefinition{
+		wd = v1alpha2.WorkloadDefinition{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "services",
-				Labels: label,
-			},
-			Spec: v1alpha2.TraitDefinitionSpec{
-				AppliesToWorkloads: []string{
-					"statefulsets.apps",
-				},
-				Reference: v1alpha2.DefinitionReference{
-					Name: "services",
-				},
-			},
-		}
-		logf.Log.Info("Creating trait definition")
-		Expect(k8sClient.Create(ctx, &tdOut)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
-		// Create a service trait CR
-		outName := "trait-trait-out"
-		svc := corev1.Service{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      outName,
-				Namespace: namespace,
-				Labels:    label,
-			},
-			Spec: corev1.ServiceSpec{
-				Selector: label,
-				Ports: []corev1.ServicePort{
-					{
-						Port:       80,
-						TargetPort: intstr.FromInt(80),
-						Name:       "web",
-						Protocol:   corev1.ProtocolTCP,
-					},
-				},
-				Type: corev1.ServiceTypeLoadBalancer,
-			},
-		}
-		// reflect trait gvk from scheme
-		gvks, _, _ := scheme.ObjectKinds(&svc)
-		svc.APIVersion = gvks[0].GroupVersion().String()
-		svc.Kind = gvks[0].Kind
-		// create another trait definition
-		tdIn := v1alpha2.TraitDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "ingresses.networking.k8s.io",
-				Labels: label,
-			},
-			Spec: v1alpha2.TraitDefinitionSpec{
-				AppliesToWorkloads: []string{
-					"statefulsets.apps",
-				},
-				Reference: v1alpha2.DefinitionReference{
-					Name: "ingresses.networking.k8s.io",
-				},
-			},
-		}
-		logf.Log.Info("Creating another trait definition")
-		Expect(k8sClient.Create(ctx, &tdIn)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
-		// Create a ingress trait CR
-		inName := "trait-trait-in"
-		ingress := v1beta1.Ingress{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      inName,
-				Namespace: namespace,
-				Labels:    label,
-			},
-			Spec: v1beta1.IngressSpec{
-				Rules: []v1beta1.IngressRule{
-					{
-						Host: "depend.oam.com",
-						IngressRuleValue: v1beta1.IngressRuleValue{
-							HTTP: &v1beta1.HTTPIngressRuleValue{
-								Paths: []v1beta1.HTTPIngressPath{
-									{
-										Path: "/",
-										Backend: v1beta1.IngressBackend{
-											ServicePort: intstr.FromInt(80),
-											ServiceName: outName,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-		// reflect trait gvk from scheme
-		gvks, _, _ = scheme.ObjectKinds(&ingress)
-		ingress.APIVersion = gvks[0].GroupVersion().String()
-		ingress.Kind = gvks[0].Kind
-		// create a workload definition
-		wd := v1alpha2.WorkloadDefinition{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "statefulsets.apps",
-				Labels: label,
+				Name: "foo.example.com",
 			},
 			Spec: v1alpha2.WorkloadDefinitionSpec{
 				Reference: v1alpha2.DefinitionReference{
-					Name: "statefulsets.apps",
+					Name: "foo.example.com",
+				},
+			},
+		}
+		td = v1alpha2.TraitDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foos.example.com",
+			},
+			Spec: v1alpha2.TraitDefinitionSpec{
+				Reference: v1alpha2.DefinitionReference{
+					Name: "foos.example.com",
 				},
 			},
 		}
 		logf.Log.Info("Creating workload definition")
 		// For some reason, WorkloadDefinition is created as a Cluster scope object
 		Expect(k8sClient.Create(ctx, &wd)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
-		stsName := "trait-trait-wl"
-		wl := appsv1.StatefulSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      stsName,
-				Namespace: namespace,
-				Labels:    label,
+		logf.Log.Info("Creating trait definition")
+		// For some reason, TraitDefinition is created as a Cluster scope object
+		Expect(k8sClient.Create(ctx, &td)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+	})
+	AfterEach(func() {
+		logf.Log.Info("Clean up resources")
+		// Delete the WorkloadDefinition and TraitDefinition
+		Expect(k8sClient.Delete(ctx, &wd)).Should(BeNil())
+		Expect(k8sClient.Delete(ctx, &td)).Should(BeNil())
+		// delete the namespace with all its resources
+		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))).Should(BeNil())
+	})
+
+	// common function for verification
+	verify := func(appConfigName, outName, inName string) {
+		// Verification before satisfying dependency
+		By("Checking that resource which accepts data isn't created yet")
+		inFooKey := client.ObjectKey{
+			Name:      inName,
+			Namespace: namespace,
+		}
+		inFoo := tempFoo.DeepCopy()
+		logf.Log.Info("Checking on resource that inputs data", "Key", inFooKey)
+		Eventually(
+			func() error {
+				return k8sClient.Get(ctx, inFooKey, inFoo)
 			},
-			Spec: appsv1.StatefulSetSpec{
-				ServiceName: outName,
-				Selector: &metav1.LabelSelector{
-					MatchLabels: label,
-				},
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: label,
+			time.Second*15, time.Millisecond*500).Should(&util.NotFoundMatcher{})
+		By("Checking that resource which provides data is created")
+		outFooKey := client.ObjectKey{
+			Name:      outName,
+			Namespace: namespace,
+		}
+		outFoo := tempFoo.DeepCopy()
+		logf.Log.Info("Checking on resource that outputs data", "Key", outFoo)
+		Eventually(
+			func() error {
+				return k8sClient.Get(ctx, outFooKey, outFoo)
+			},
+			time.Second*15, time.Millisecond*500).Should(BeNil())
+		By("Verify the appconfig's dependency is unsatisfied")
+		appconfigKey := client.ObjectKey{
+			Name:      appConfigName,
+			Namespace: namespace,
+		}
+		appconfig := &v1alpha2.ApplicationConfiguration{}
+		depStatus := v1alpha2.DependencyStatus{
+			Unsatisfied: []v1alpha2.UnstaifiedDependency{
+				{
+					From: v1alpha2.DependencyFromObject{
+						TypedReference: runtimev1alpha1.TypedReference{
+							APIVersion: tempFoo.GetAPIVersion(),
+							Name:       outName,
+							Kind:       tempFoo.GetKind(),
+						},
+						FieldPath: "status.key",
 					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  "nginx",
-								Image: "nginx:1.17",
-								Ports: []corev1.ContainerPort{
-									{
-										ContainerPort: 80,
-									},
-								},
-							},
+					To: v1alpha2.DependencyToObject{
+						TypedReference: runtimev1alpha1.TypedReference{
+							APIVersion: tempFoo.GetAPIVersion(),
+							Name:       inName,
+							Kind:       tempFoo.GetKind(),
+						},
+						FieldPaths: []string{
+							"spec.key",
 						},
 					},
 				},
 			},
 		}
-		// reflect workload gvk from scheme
-		gvks, _, _ = scheme.ObjectKinds(&wl)
-		wl.APIVersion = gvks[0].GroupVersion().String()
-		wl.Kind = gvks[0].Kind
-		// Create a component definition
-		componentName := "component-trait-trait"
+		logf.Log.Info("Checking on appconfig", "Key", appconfigKey)
+		Eventually(
+			func() v1alpha2.DependencyStatus {
+				k8sClient.Get(ctx, appconfigKey, appconfig)
+				return appconfig.Status.Dependency
+			},
+			time.Second*15, time.Millisecond*500).Should(Equal(depStatus))
+		// fill value to fieldPath
+		err := unstructured.SetNestedField(outFoo.Object, "test", "status", "key")
+		Expect(err).Should(BeNil())
+		Expect(k8sClient.Update(ctx, outFoo)).Should(Succeed())
+		// Verification after satisfying dependency
+		By("Checking that resource which accepts data is created now")
+		logf.Log.Info("Checking on resource that inputs data", "Key", inFooKey)
+		Eventually(
+			func() error {
+				return k8sClient.Get(ctx, inFooKey, inFoo)
+			},
+			time.Second*15, time.Millisecond*500).Should(BeNil())
+		By("Verify the appconfig's dependency is unsatisfied")
+		appconfig = &v1alpha2.ApplicationConfiguration{}
+		logf.Log.Info("Checking on appconfig", "Key", appconfigKey)
+		Eventually(
+			func() []v1alpha2.UnstaifiedDependency {
+				k8sClient.Get(ctx, appconfigKey, appconfig)
+				return appconfig.Status.Dependency.Unsatisfied
+			},
+			time.Second*15, time.Millisecond*500).Should(BeNil())
+	}
+
+	It("trait depends on another trait", func() {
+		label := map[string]string{"trait": "trait"}
+		// Define a trait which provides data
+		outName := "trait-out"
+		tdOut := tempFoo.DeepCopy()
+		tdOut.SetName(outName)
+		// Define a trait which accepts data
+		inName := "trait-in"
+		tdIn := tempFoo.DeepCopy()
+		tdIn.SetName(inName)
+		// Define a workload
+		wlName := "wl"
+		wl := tempFoo.DeepCopy()
+		wl.SetName(wlName)
+		// Create a component
+		componentName := "component"
 		comp := v1alpha2.Component{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      componentName,
@@ -210,12 +203,12 @@ var _ = Describe("AppconfigDependency", func() {
 			},
 			Spec: v1alpha2.ComponentSpec{
 				Workload: runtime.RawExtension{
-					Object: &wl,
+					Object: wl,
 				},
 			},
 		}
-		logf.Log.Info("Creating component", "Name", comp.Name, "Namespace", comp.Namespace)
 		Expect(k8sClient.Create(ctx, &comp)).Should(BeNil())
+		logf.Log.Info("Creating component", "Name", comp.Name, "Namespace", comp.Namespace)
 		// Create application configuration
 		appConfigName := "appconfig-trait-trait"
 		appConfig := v1alpha2.ApplicationConfiguration{
@@ -231,31 +224,25 @@ var _ = Describe("AppconfigDependency", func() {
 						Traits: []v1alpha2.ComponentTrait{
 							{
 								Trait: runtime.RawExtension{
-									Object: &svc,
+									Object: tdOut,
 								},
 								DataOutputs: []v1alpha2.DataOutput{
 									{
-										Name:      "test",
-										FieldPath: "spec.externalTrafficPolicy",
-										Conditions: []v1alpha2.ConditionRequirement{
-											{
-												Operator:  "eq",
-												Value:     "Local",
-												FieldPath: "spec.externalTrafficPolicy",
-											},
-										},
+										Name:      "trait-trait",
+										FieldPath: "status.key",
 									},
 								},
 							},
 							{
 								Trait: runtime.RawExtension{
-									Object: &ingress,
+									Object: tdIn,
 								},
 								DataInputs: []v1alpha2.DataInput{
 									{
 										ValueFrom: v1alpha2.DataInputValueFrom{
-											DataOutputName: "test",
+											DataOutputName: "trait-trait",
 										},
+										ToFieldPaths: []string{"spec.key"},
 									},
 								},
 							},
@@ -266,83 +253,222 @@ var _ = Describe("AppconfigDependency", func() {
 		}
 		logf.Log.Info("Creating application config", "Name", appConfig.Name, "Namespace", appConfig.Namespace)
 		Expect(k8sClient.Create(ctx, &appConfig)).Should(BeNil())
-		// Verification before satisfying dependency
-		By("Checking that trait which accepts data isn't created yet")
-		ingressKey := client.ObjectKey{
-			Name:      inName,
-			Namespace: namespace,
-		}
-		ingressIn := &v1beta1.Ingress{}
-		logf.Log.Info("Checking on ingress that inputs data", "Key", ingressKey)
-		Eventually(
-			func() error {
-				return k8sClient.Get(ctx, ingressKey, ingressIn)
+		verify(appConfigName, outName, inName)
+	})
+
+	It("component depends on another component", func() {
+		label := map[string]string{"component": "component"}
+		// Define a workload which provides data
+		outName := "comp-out"
+		wlOut := tempFoo.DeepCopy()
+		wlOut.SetName(outName)
+		// Define a workload which accepts data
+		inName := "comp-in"
+		wlIn := tempFoo.DeepCopy()
+		wlIn.SetName(inName)
+		// Create a component
+		componentOutName := "component-comp-out"
+		compOut := v1alpha2.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      componentOutName,
+				Namespace: namespace,
+				Labels:    label,
 			},
-			time.Second*15, time.Millisecond*500).Should(&util.NotFoundMatcher{})
-		By("Checking that trait which provides data is created")
-		svcKey := client.ObjectKey{
-			Name:      outName,
-			Namespace: namespace,
-		}
-		svcOut := &corev1.Service{}
-		logf.Log.Info("Checking on service that outputs data", "Key", svcKey)
-		Eventually(
-			func() error {
-				return k8sClient.Get(ctx, svcKey, svcOut)
-			},
-			time.Second*15, time.Millisecond*500).Should(BeNil())
-		By("Verify the appconfig's dependency is unsatisfied")
-		appconfigKey := client.ObjectKey{
-			Name:      appConfigName,
-			Namespace: namespace,
-		}
-		appconfig := &v1alpha2.ApplicationConfiguration{}
-		unsatisfiedStatus := []v1alpha2.UnstaifiedDependency{
-			{
-				From: v1alpha2.DependencyFromObject{
-					TypedReference: runtimev1alpha1.TypedReference{
-						APIVersion: corev1.SchemeGroupVersion.String(),
-						Name:       outName,
-						Kind:       "Service",
-					},
-					FieldPath: "spec.externalTrafficPolicy",
-				},
-				To: v1alpha2.DependencyToObject{
-					TypedReference: runtimev1alpha1.TypedReference{
-						APIVersion: v1beta1.SchemeGroupVersion.String(),
-						Name:       inName,
-						Kind:       "Ingress",
-					},
+			Spec: v1alpha2.ComponentSpec{
+				Workload: runtime.RawExtension{
+					Object: wlOut,
 				},
 			},
 		}
-		logf.Log.Info("Checking on appconfig", "Key", appconfigKey)
-		Eventually(
-			func() error {
-				return k8sClient.Get(ctx, appconfigKey, appconfig)
+		Expect(k8sClient.Create(ctx, &compOut)).Should(BeNil())
+		logf.Log.Info("Creating component that outputs data", "Name", compOut.Name, "Namespace", compOut.Namespace)
+		// Create another component
+		componentInName := "component-comp-in"
+		compIn := v1alpha2.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      componentInName,
+				Namespace: namespace,
+				Labels:    label,
 			},
-			time.Second*15, time.Millisecond*500).Should(BeNil())
-		Expect(appconfig.Status.Dependency.Unsatisfied).Should(Equal(unsatisfiedStatus))
-		// fill value to fieldPath
-		updated := svcOut
-		updated.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
-		Expect(k8sClient.Update(ctx, updated)).Should(Succeed())
-		// Verification after satisfying dependency
-		By("Checking that trait which accepts data is created now")
-		logf.Log.Info("Checking on ingress that inputs data", "Key", ingressKey)
-		Eventually(
-			func() error {
-				return k8sClient.Get(ctx, ingressKey, ingressIn)
+			Spec: v1alpha2.ComponentSpec{
+				Workload: runtime.RawExtension{
+					Object: wlIn,
+				},
 			},
-			time.Second*15, time.Millisecond*500).Should(BeNil())
-		By("Verify the appconfig's dependency is satisfied")
-		appconfig = &v1alpha2.ApplicationConfiguration{}
-		logf.Log.Info("Checking on appconfig", "Key", appconfigKey)
-		Eventually(
-			func() error {
-				return k8sClient.Get(ctx, appconfigKey, appconfig)
+		}
+		Expect(k8sClient.Create(ctx, &compIn)).Should(BeNil())
+		logf.Log.Info("Creating component that inputs data", "Name", compIn.Name, "Namespace", compIn.Namespace)
+		// Create application configuration
+		appConfigName := "appconfig-comp-comp"
+		appConfig := v1alpha2.ApplicationConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      appConfigName,
+				Namespace: namespace,
+				Labels:    label,
 			},
-			time.Second*15, time.Millisecond*500).Should(BeNil())
-		Expect(appconfig.Status.Dependency.Unsatisfied).Should(BeNil())
+			Spec: v1alpha2.ApplicationConfigurationSpec{
+				Components: []v1alpha2.ApplicationConfigurationComponent{
+					{
+						ComponentName: componentOutName,
+						DataOutputs: []v1alpha2.DataOutput{
+							{
+								Name:      "comp-comp",
+								FieldPath: "status.key",
+							},
+						},
+					},
+					{
+						ComponentName: componentInName,
+						DataInputs: []v1alpha2.DataInput{
+							{
+								ValueFrom: v1alpha2.DataInputValueFrom{
+									DataOutputName: "comp-comp",
+								},
+								ToFieldPaths: []string{"spec.key"},
+							},
+						},
+					},
+				},
+			},
+		}
+		logf.Log.Info("Creating application config", "Name", appConfig.Name, "Namespace", appConfig.Namespace)
+		Expect(k8sClient.Create(ctx, &appConfig)).Should(BeNil())
+		verify(appConfigName, outName, inName)
+	})
+
+	It("component depends on trait", func() {
+		label := map[string]string{"trait": "component"}
+		// Define a trait which provides data
+		outName := "trait-out"
+		tdOut := tempFoo.DeepCopy()
+		tdOut.SetName(outName)
+		// Define a workload which accepts data
+		inName := "comp-in"
+		wlIn := tempFoo.DeepCopy()
+		wlIn.SetName(inName)
+		// Create a component
+		componentInName := "component-comp-in"
+		compIn := v1alpha2.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      componentInName,
+				Namespace: namespace,
+				Labels:    label,
+			},
+			Spec: v1alpha2.ComponentSpec{
+				Workload: runtime.RawExtension{
+					Object: wlIn,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, &compIn)).Should(BeNil())
+		logf.Log.Info("Creating component that inputs data", "Name", compIn.Name, "Namespace", compIn.Namespace)
+		// Create application configuration
+		appConfigName := "appconfig-trait-comp"
+		appConfig := v1alpha2.ApplicationConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      appConfigName,
+				Namespace: namespace,
+				Labels:    label,
+			},
+			Spec: v1alpha2.ApplicationConfigurationSpec{
+				Components: []v1alpha2.ApplicationConfigurationComponent{
+					{
+						ComponentName: componentInName,
+						DataInputs: []v1alpha2.DataInput{
+							{
+								ValueFrom: v1alpha2.DataInputValueFrom{
+									DataOutputName: "trait-comp",
+								},
+								ToFieldPaths: []string{"spec.key"},
+							},
+						},
+						Traits: []v1alpha2.ComponentTrait{
+							{
+								Trait: runtime.RawExtension{
+									Object: tdOut,
+								},
+								DataOutputs: []v1alpha2.DataOutput{
+									{
+										Name:      "trait-comp",
+										FieldPath: "status.key",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		logf.Log.Info("Creating application config", "Name", appConfig.Name, "Namespace", appConfig.Namespace)
+		Expect(k8sClient.Create(ctx, &appConfig)).Should(BeNil())
+		verify(appConfigName, outName, inName)
+	})
+
+	It("trait depends on component", func() {
+		label := map[string]string{"component": "trait"}
+		// Define a workload which provides data
+		outName := "comp-out"
+		wlOut := tempFoo.DeepCopy()
+		wlOut.SetName(outName)
+		// Define a trait which accepts data
+		inName := "trait-in"
+		tdIn := tempFoo.DeepCopy()
+		tdIn.SetName(inName)
+		// Create a component
+		componentOutName := "component-comp-out"
+		compOut := v1alpha2.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      componentOutName,
+				Namespace: namespace,
+				Labels:    label,
+			},
+			Spec: v1alpha2.ComponentSpec{
+				Workload: runtime.RawExtension{
+					Object: wlOut,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, &compOut)).Should(BeNil())
+		logf.Log.Info("Creating component that outputs data", "Name", compOut.Name, "Namespace", compOut.Namespace)
+		// Create application configuration
+		appConfigName := "appconfig-comp-trait"
+		appConfig := v1alpha2.ApplicationConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      appConfigName,
+				Namespace: namespace,
+				Labels:    label,
+			},
+			Spec: v1alpha2.ApplicationConfigurationSpec{
+				Components: []v1alpha2.ApplicationConfigurationComponent{
+					{
+						ComponentName: componentOutName,
+						DataOutputs: []v1alpha2.DataOutput{
+							{
+								Name:      "comp-trait",
+								FieldPath: "status.key",
+							},
+						},
+						Traits: []v1alpha2.ComponentTrait{
+							{
+								Trait: runtime.RawExtension{
+									Object: tdIn,
+								},
+								DataInputs: []v1alpha2.DataInput{
+									{
+										ValueFrom: v1alpha2.DataInputValueFrom{
+											DataOutputName: "comp-trait",
+										},
+										ToFieldPaths: []string{"spec.key"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		logf.Log.Info("Creating application config", "Name", appConfig.Name, "Namespace", appConfig.Namespace)
+		Expect(k8sClient.Create(ctx, &appConfig)).Should(BeNil())
+		verify(appConfigName, outName, inName)
 	})
 })

--- a/test/e2e-test/appconfig_dependency_test.go
+++ b/test/e2e-test/appconfig_dependency_test.go
@@ -30,6 +30,12 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 	tempFoo.SetAPIVersion("example.com/v1")
 	tempFoo.SetKind("Foo")
 	tempFoo.SetNamespace(namespace)
+	outName := "data-output"
+	out := tempFoo.DeepCopy()
+	out.SetName(outName)
+	inName := "data-input"
+	in := tempFoo.DeepCopy()
+	in.SetName(inName)
 	BeforeEach(func() {
 		ns = corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -94,7 +100,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 	})
 
 	// common function for verification
-	verify := func(appConfigName, outName, inName string) {
+	verify := func(appConfigName string) {
 		// Verification before satisfying dependency
 		By("Checking that resource which accepts data isn't created yet")
 		inFooKey := client.ObjectKey{
@@ -182,18 +188,9 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 
 	It("trait depends on another trait", func() {
 		label := map[string]string{"trait": "trait"}
-		// Define a trait which provides data
-		outName := "trait-out"
-		tdOut := tempFoo.DeepCopy()
-		tdOut.SetName(outName)
-		// Define a trait which accepts data
-		inName := "trait-in"
-		tdIn := tempFoo.DeepCopy()
-		tdIn.SetName(inName)
 		// Define a workload
-		wlName := "wl"
 		wl := tempFoo.DeepCopy()
-		wl.SetName(wlName)
+		wl.SetName("workload")
 		// Create a component
 		componentName := "component"
 		comp := v1alpha2.Component{
@@ -225,7 +222,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 						Traits: []v1alpha2.ComponentTrait{
 							{
 								Trait: runtime.RawExtension{
-									Object: tdOut,
+									Object: out,
 								},
 								DataOutputs: []v1alpha2.DataOutput{
 									{
@@ -236,7 +233,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 							},
 							{
 								Trait: runtime.RawExtension{
-									Object: tdIn,
+									Object: in,
 								},
 								DataInputs: []v1alpha2.DataInput{
 									{
@@ -254,19 +251,11 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 		}
 		logf.Log.Info("Creating application config", "Name", appConfig.Name, "Namespace", appConfig.Namespace)
 		Expect(k8sClient.Create(ctx, &appConfig)).Should(BeNil())
-		verify(appConfigName, outName, inName)
+		verify(appConfigName)
 	})
 
 	It("component depends on another component", func() {
 		label := map[string]string{"component": "component"}
-		// Define a workload which provides data
-		outName := "comp-out"
-		wlOut := tempFoo.DeepCopy()
-		wlOut.SetName(outName)
-		// Define a workload which accepts data
-		inName := "comp-in"
-		wlIn := tempFoo.DeepCopy()
-		wlIn.SetName(inName)
 		// Create a component
 		componentOutName := "component-comp-out"
 		compOut := v1alpha2.Component{
@@ -277,7 +266,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 			},
 			Spec: v1alpha2.ComponentSpec{
 				Workload: runtime.RawExtension{
-					Object: wlOut,
+					Object: out,
 				},
 			},
 		}
@@ -293,7 +282,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 			},
 			Spec: v1alpha2.ComponentSpec{
 				Workload: runtime.RawExtension{
-					Object: wlIn,
+					Object: in,
 				},
 			},
 		}
@@ -334,19 +323,11 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 		}
 		logf.Log.Info("Creating application config", "Name", appConfig.Name, "Namespace", appConfig.Namespace)
 		Expect(k8sClient.Create(ctx, &appConfig)).Should(BeNil())
-		verify(appConfigName, outName, inName)
+		verify(appConfigName)
 	})
 
 	It("component depends on trait", func() {
 		label := map[string]string{"trait": "component"}
-		// Define a trait which provides data
-		outName := "trait-out"
-		tdOut := tempFoo.DeepCopy()
-		tdOut.SetName(outName)
-		// Define a workload which accepts data
-		inName := "comp-in"
-		wlIn := tempFoo.DeepCopy()
-		wlIn.SetName(inName)
 		// Create a component
 		componentInName := "component-comp-in"
 		compIn := v1alpha2.Component{
@@ -357,7 +338,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 			},
 			Spec: v1alpha2.ComponentSpec{
 				Workload: runtime.RawExtension{
-					Object: wlIn,
+					Object: in,
 				},
 			},
 		}
@@ -386,7 +367,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 						Traits: []v1alpha2.ComponentTrait{
 							{
 								Trait: runtime.RawExtension{
-									Object: tdOut,
+									Object: out,
 								},
 								DataOutputs: []v1alpha2.DataOutput{
 									{
@@ -402,19 +383,11 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 		}
 		logf.Log.Info("Creating application config", "Name", appConfig.Name, "Namespace", appConfig.Namespace)
 		Expect(k8sClient.Create(ctx, &appConfig)).Should(BeNil())
-		verify(appConfigName, outName, inName)
+		verify(appConfigName)
 	})
 
 	It("trait depends on component", func() {
 		label := map[string]string{"component": "trait"}
-		// Define a workload which provides data
-		outName := "comp-out"
-		wlOut := tempFoo.DeepCopy()
-		wlOut.SetName(outName)
-		// Define a trait which accepts data
-		inName := "trait-in"
-		tdIn := tempFoo.DeepCopy()
-		tdIn.SetName(inName)
 		// Create a component
 		componentOutName := "component-comp-out"
 		compOut := v1alpha2.Component{
@@ -425,7 +398,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 			},
 			Spec: v1alpha2.ComponentSpec{
 				Workload: runtime.RawExtension{
-					Object: wlOut,
+					Object: out,
 				},
 			},
 		}
@@ -452,7 +425,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 						Traits: []v1alpha2.ComponentTrait{
 							{
 								Trait: runtime.RawExtension{
-									Object: tdIn,
+									Object: in,
 								},
 								DataInputs: []v1alpha2.DataInput{
 									{
@@ -470,6 +443,6 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 		}
 		logf.Log.Info("Creating application config", "Name", appConfig.Name, "Namespace", appConfig.Namespace)
 		Expect(k8sClient.Create(ctx, &appConfig)).Should(BeNil())
-		verify(appConfigName, outName, inName)
+		verify(appConfigName)
 	})
 })

--- a/test/e2e-test/appconfig_dependency_test.go
+++ b/test/e2e-test/appconfig_dependency_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -14,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam/util"
 )
@@ -129,7 +129,7 @@ var _ = Describe("AppconfigDependency", func() {
 			Unsatisfied: []v1alpha2.UnstaifiedDependency{
 				{
 					From: v1alpha2.DependencyFromObject{
-						TypedReference: runtimev1alpha1.TypedReference{
+						TypedReference: v1alpha1.TypedReference{
 							APIVersion: tempFoo.GetAPIVersion(),
 							Name:       outName,
 							Kind:       tempFoo.GetKind(),
@@ -137,7 +137,7 @@ var _ = Describe("AppconfigDependency", func() {
 						FieldPath: "status.key",
 					},
 					To: v1alpha2.DependencyToObject{
-						TypedReference: runtimev1alpha1.TypedReference{
+						TypedReference: v1alpha1.TypedReference{
 							APIVersion: tempFoo.GetAPIVersion(),
 							Name:       inName,
 							Kind:       tempFoo.GetKind(),


### PR DESCRIPTION
This e2e test will cover four cases below:
- [x] A trait depends on another trait.
- [x] A component depends on another component.
- [x] A trait depends on a component.
- [x] A component depends on a trait.

The test process for each of these cases consists of two steps:
1. When dependency conditions don't meet requirement, trait or component won't create, and it's unsatisfied dependency will show on `appconfig.status.dependency`.
2. Fill in fieldPath to let conditions meet, trait or component successfully created, and `appconfig.status.dependency` will be nil.