### PR TITLE
Move Dockerfile to images dir for compatability with build submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,19 +51,9 @@ GO111MODULE = on
 # all be in folders at the same level (no additional levels of nesting).
 
 DOCKER_REGISTRY = crossplane
-IMAGE_DIR=$(ROOT_DIR)
-IMAGE = $(BUILD_REGISTRY)/oam-kubernetes-runtime-$(ARCH)
+IMAGE_DIR=$(ROOT_DIR)/images
+IMAGES = oam-kubernetes-runtime
 -include build/makelib/image.mk
-
-img.build:
-	@$(INFO) docker build $(IMAGE)
-	@cp -r . $(IMAGE_TEMP_DIR) || $(FAIL)
-	@cp $(OUTPUT_DIR)/bin/$(OS)_$(ARCH)/oam-kubernetes-runtime $(IMAGE_TEMP_DIR) || $(FAIL)
-	@cd $(IMAGE_TEMP_DIR) || $(FAIL)
-	@docker build $(BUILD_ARGS) \
-		-t $(IMAGE) \
-		$(IMAGE_TEMP_DIR) || $(FAIL)
-	@$(OK) docker build $(IMAGE)
 
 # ====================================================================================
 # Targets
@@ -127,7 +117,7 @@ help-special: oam-kubernetes-runtime.help
 
 # load docker image to the kind cluster
 kind-load:
-	docker tag $(IMAGE) crossplane/oam-kubernetes-runtime:$(VERSION)
+	docker tag $(BUILD_REGISTRY)/oam-kubernetes-runtime-$(ARCH) crossplane/oam-kubernetes-runtime:$(VERSION)
 	kind load docker-image crossplane/oam-kubernetes-runtime:$(VERSION) || { echo >&2 "kind not installed or error loading image: $(IMAGE)"; exit 1; }
 
 e2e-setup: build kind-load

--- a/images/oam-kubernetes-runtime/Dockerfile
+++ b/images/oam-kubernetes-runtime/Dockerfile
@@ -1,0 +1,27 @@
+# Build the manager binary
+FROM golang:1.13 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY apis/ apis/
+COPY pkg/ pkg/
+COPY cmd/oam-kubernetes-runtime/main.go main.go
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o controller main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/controller .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/controller"]

--- a/images/oam-kubernetes-runtime/Makefile
+++ b/images/oam-kubernetes-runtime/Makefile
@@ -1,0 +1,23 @@
+# ====================================================================================
+# Setup Project
+
+PLATFORMS := linux_amd64 linux_arm64
+include ../../build/makelib/common.mk
+
+# ====================================================================================
+#  Options
+IMAGE = $(BUILD_REGISTRY)/oam-kubernetes-runtime-$(ARCH)
+include ../../build/makelib/image.mk
+
+# ====================================================================================
+# Targets
+
+img.build:
+	@$(INFO) docker build $(IMAGE)
+	@cp -r ../.. $(IMAGE_TEMP_DIR) || $(FAIL)
+	@cp $(OUTPUT_DIR)/bin/$(OS)_$(ARCH)/oam-kubernetes-runtime $(IMAGE_TEMP_DIR) || $(FAIL)
+	@cd $(IMAGE_TEMP_DIR) || $(FAIL)
+	@docker build $(BUILD_ARGS) \
+		-t $(IMAGE) \
+		$(IMAGE_TEMP_DIR) || $(FAIL)
+	@$(OK) docker build $(IMAGE)


### PR DESCRIPTION
I believe this will fix the issue of the image and helm chart not being published.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>