### PR TITLE
update status of some proposals.

### DIFF
--- a/design/one-pager-component-mutable-and-versioning.md
+++ b/design/one-pager-component-mutable-and-versioning.md
@@ -2,7 +2,7 @@
 
 * Owner: Lei Zhang (@resouer), Jianbo Sun (@wonderflow)
 * Reviewers: Crossplane Maintainers
-* Status: Draft
+* Status: Implemented
 
 ## Terminology
 

--- a/design/resource-dependency.md
+++ b/design/resource-dependency.md
@@ -2,7 +2,7 @@
 
 - Owner: Hongchao Deng (@hongchaodeng)
 - Date: 05/17/2020
-- Status: Draft
+- Status: Implemented
 
 ## Background
 

--- a/design/workload-rollout-model.md
+++ b/design/workload-rollout-model.md
@@ -2,7 +2,7 @@
 
 * Owner: Jianbo Sun (@wonderflow)
 * Reviewers: Crossplane Maintainers
-* Status: Draft
+* Status: Approved
 
 ## Background
 


### PR DESCRIPTION
1. component versioning implemented by https://github.com/crossplane/oam-kubernetes-runtime/pull/35
2. dependency implemented by https://github.com/crossplane/oam-kubernetes-runtime/pull/74 and https://github.com/crossplane/oam-kubernetes-runtime/pull/53
3. rollout model don't need any change, it's best practice

Signed-off-by: 天元 <jianbo.sjb@alibaba-inc.com>