### PR TITLE
Add release artifacts bucket to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ PLATFORMS ?= linux_amd64 linux_arm64
 # ====================================================================================
 # Setup Output
 
+S3_BUCKET ?= crossplane.releases/oam
 -include build/makelib/output.mk
 
 # ====================================================================================


### PR DESCRIPTION
This updates the Makefile to publish release artifacts to
crossplane.releases/oam which enables the publishing of the helm chart
to crossplane.charts.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>