### PR TITLE
Generate v1 CRD instead of v1beta1

### DIFF
--- a/apis/generate.go
+++ b/apis/generate.go
@@ -23,7 +23,7 @@ limitations under the License.
 //go:generate rm -rf ../charts/oam-kubernetes-runtime/crds
 
 // Generate deepcopy methodsets and CRD manifests
-//go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile=../hack/boilerplate.go.txt paths=./... crd:trivialVersions=true output:artifacts:config=../charts/oam-kubernetes-runtime/crds
+//go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile=../hack/boilerplate.go.txt paths=./... crd:crdVersions=v1 output:artifacts:config=../charts/oam-kubernetes-runtime/crds
 
 package apis
 

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_applicationconfigurations.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_applicationconfigurations.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -20,372 +20,306 @@ spec:
     - appconfig
     singular: applicationconfiguration
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: An ApplicationConfiguration represents an OAM application.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: An ApplicationConfigurationSpec defines the desired state of
-            a ApplicationConfiguration.
-          properties:
-            components:
-              description: Components of which this ApplicationConfiguration consists.
-                Each component will be used to instantiate a workload.
-              items:
-                description: An ApplicationConfigurationComponent specifies a component
-                  of an ApplicationConfiguration. Each component is used to instantiate
-                  a workload.
-                properties:
-                  componentName:
-                    description: ComponentName specifies a component whose latest
-                      revision will be bind with ApplicationConfiguration. When the
-                      spec of the referenced component changes, ApplicationConfiguration
-                      will automatically migrate all trait affect from the prior revision
-                      to the new one. This is mutually exclusive with RevisionName.
-                    type: string
-                  dataInputs:
-                    description: DataInputs specify the data input sinks into this
-                      component.
-                    items:
-                      description: DataInput specifies a data input sink to an object.
-                      properties:
-                        toFieldPaths:
-                          description: ToFieldPaths specifies the field paths of an
-                            object to fill passed value.
-                          items:
-                            type: string
-                          type: array
-                        valueFrom:
-                          description: ValueFrom specifies the value source.
-                          properties:
-                            dataOutputName:
-                              description: DataOutputName matches a name of a DataOutput
-                                in the same AppConfig.
-                              type: string
-                          required:
-                          - dataOutputName
-                          type: object
-                      type: object
-                    type: array
-                  dataOutputs:
-                    description: DataOutputs specify the data output sources from
-                      this component.
-                    items:
-                      description: DataOutput specifies a data output source from
-                        an object.
-                      properties:
-                        conditions:
-                          description: Conditions specify the conditions that should
-                            be satisfied before emitting a data output. Different
-                            conditions are AND-ed together. If no conditions is specified,
-                            it is by default to check output value not empty.
-                          items:
-                            description: ConditionRequirement specifies the requirement
-                              to match a value.
-                            properties:
-                              fieldPath:
-                                type: string
-                              op:
-                                description: ConditionOperator specifies the operator
-                                  to match a value.
-                                type: string
-                              value:
-                                type: string
-                            required:
-                            - op
-                            - value
-                            type: object
-                          type: array
-                        fieldPath:
-                          description: FieldPath refers to the value of an object's
-                            field.
-                          type: string
-                        name:
-                          description: Name is the unique name of a DataOutput in
-                            an ApplicationConfiguration.
-                          type: string
-                      type: object
-                    type: array
-                  parameterValues:
-                    description: ParameterValues specify values for the the specified
-                      component's parameters. Any parameter required by the component
-                      must be specified.
-                    items:
-                      description: A ComponentParameterValue specifies a value for
-                        a named parameter. The associated component must publish a
-                        parameter with this name.
-                      properties:
-                        name:
-                          description: Name of the component parameter to set.
-                          type: string
-                        value:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: Value to set.
-                          x-kubernetes-int-or-string: true
-                      required:
-                      - name
-                      - value
-                      type: object
-                    type: array
-                  revisionName:
-                    description: RevisionName of a specific component revision to
-                      which to bind ApplicationConfiguration. This is mutually exclusive
-                      with componentName.
-                    type: string
-                  scopes:
-                    description: Scopes in which the specified component should exist.
-                    items:
-                      description: A ComponentScope specifies a scope in which a component
-                        should exist.
-                      properties:
-                        scopeRef:
-                          description: A ScopeReference must refer to an OAM scope
-                            resource.
-                          properties:
-                            apiVersion:
-                              description: APIVersion of the referenced object.
-                              type: string
-                            kind:
-                              description: Kind of the referenced object.
-                              type: string
-                            name:
-                              description: Name of the referenced object.
-                              type: string
-                            uid:
-                              description: UID of the referenced object.
-                              type: string
-                          required:
-                          - apiVersion
-                          - kind
-                          - name
-                          type: object
-                      required:
-                      - scopeRef
-                      type: object
-                    type: array
-                  traits:
-                    description: Traits of the specified component.
-                    items:
-                      description: A ComponentTrait specifies a trait that should
-                        be applied to a component.
-                      properties:
-                        dataInputs:
-                          description: DataInputs specify the data input sinks into
-                            this trait.
-                          items:
-                            description: DataInput specifies a data input sink to
-                              an object.
-                            properties:
-                              toFieldPaths:
-                                description: ToFieldPaths specifies the field paths
-                                  of an object to fill passed value.
-                                items:
-                                  type: string
-                                type: array
-                              valueFrom:
-                                description: ValueFrom specifies the value source.
-                                properties:
-                                  dataOutputName:
-                                    description: DataOutputName matches a name of
-                                      a DataOutput in the same AppConfig.
-                                    type: string
-                                required:
-                                - dataOutputName
-                                type: object
-                            type: object
-                          type: array
-                        dataOutputs:
-                          description: DataOutputs specify the data output sources
-                            from this trait.
-                          items:
-                            description: DataOutput specifies a data output source
-                              from an object.
-                            properties:
-                              conditions:
-                                description: Conditions specify the conditions that
-                                  should be satisfied before emitting a data output.
-                                  Different conditions are AND-ed together. If no
-                                  conditions is specified, it is by default to check
-                                  output value not empty.
-                                items:
-                                  description: ConditionRequirement specifies the
-                                    requirement to match a value.
-                                  properties:
-                                    fieldPath:
-                                      type: string
-                                    op:
-                                      description: ConditionOperator specifies the
-                                        operator to match a value.
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - op
-                                  - value
-                                  type: object
-                                type: array
-                              fieldPath:
-                                description: FieldPath refers to the value of an object's
-                                  field.
-                                type: string
-                              name:
-                                description: Name is the unique name of a DataOutput
-                                  in an ApplicationConfiguration.
-                                type: string
-                            type: object
-                          type: array
-                        trait:
-                          description: A Trait that will be created for the component
-                          type: object
-                          x-kubernetes-embedded-resource: true
-                          x-kubernetes-preserve-unknown-fields: true
-                      required:
-                      - trait
-                      type: object
-                    type: array
-                type: object
-              type: array
-          required:
-          - components
-          type: object
-        status:
-          description: An ApplicationConfigurationStatus represents the observed state
-            of a ApplicationConfiguration.
-          properties:
-            conditions:
-              description: Conditions of the resource.
-              items:
-                description: A Condition that may apply to a resource.
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time this condition
-                      transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A Message containing details about this condition's
-                      last transition from one status to another, if any.
-                    type: string
-                  reason:
-                    description: A Reason for this condition's last transition from
-                      one status to another.
-                    type: string
-                  status:
-                    description: Status of this condition; is it currently True, False,
-                      or Unknown?
-                    type: string
-                  type:
-                    description: Type of this condition. At most one of each condition
-                      type may apply to a resource at any point in time.
-                    type: string
-                required:
-                - lastTransitionTime
-                - reason
-                - status
-                - type
-                type: object
-              type: array
-            dependency:
-              description: DependencyStatus represents the observed state of the dependency
-                of an ApplicationConfiguration.
-              properties:
-                unsatisfied:
-                  items:
-                    description: UnstaifiedDependency describes unsatisfied dependency
-                      flow between one pair of objects.
-                    properties:
-                      from:
-                        description: DependencyFromObject represents the object that
-                          dependency data comes from.
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: An ApplicationConfiguration represents an OAM application.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: An ApplicationConfigurationSpec defines the desired state
+              of a ApplicationConfiguration.
+            properties:
+              components:
+                description: Components of which this ApplicationConfiguration consists.
+                  Each component will be used to instantiate a workload.
+                items:
+                  description: An ApplicationConfigurationComponent specifies a component
+                    of an ApplicationConfiguration. Each component is used to instantiate
+                    a workload.
+                  properties:
+                    componentName:
+                      description: ComponentName specifies a component whose latest
+                        revision will be bind with ApplicationConfiguration. When
+                        the spec of the referenced component changes, ApplicationConfiguration
+                        will automatically migrate all trait affect from the prior
+                        revision to the new one. This is mutually exclusive with RevisionName.
+                      type: string
+                    dataInputs:
+                      description: DataInputs specify the data input sinks into this
+                        component.
+                      items:
+                        description: DataInput specifies a data input sink to an object.
                         properties:
-                          apiVersion:
-                            description: APIVersion of the referenced object.
-                            type: string
-                          fieldPath:
-                            type: string
-                          kind:
-                            description: Kind of the referenced object.
-                            type: string
-                          name:
-                            description: Name of the referenced object.
-                            type: string
-                          uid:
-                            description: UID of the referenced object.
-                            type: string
-                        required:
-                        - apiVersion
-                        - kind
-                        - name
-                        type: object
-                      to:
-                        description: DependencyToObject represents the object that
-                          dependency data goes to.
-                        properties:
-                          apiVersion:
-                            description: APIVersion of the referenced object.
-                            type: string
-                          fieldPaths:
+                          toFieldPaths:
+                            description: ToFieldPaths specifies the field paths of
+                              an object to fill passed value.
                             items:
                               type: string
                             type: array
-                          kind:
-                            description: Kind of the referenced object.
+                          valueFrom:
+                            description: ValueFrom specifies the value source.
+                            properties:
+                              dataOutputName:
+                                description: DataOutputName matches a name of a DataOutput
+                                  in the same AppConfig.
+                                type: string
+                            required:
+                            - dataOutputName
+                            type: object
+                        type: object
+                      type: array
+                    dataOutputs:
+                      description: DataOutputs specify the data output sources from
+                        this component.
+                      items:
+                        description: DataOutput specifies a data output source from
+                          an object.
+                        properties:
+                          conditions:
+                            description: Conditions specify the conditions that should
+                              be satisfied before emitting a data output. Different
+                              conditions are AND-ed together. If no conditions is
+                              specified, it is by default to check output value not
+                              empty.
+                            items:
+                              description: ConditionRequirement specifies the requirement
+                                to match a value.
+                              properties:
+                                fieldPath:
+                                  type: string
+                                op:
+                                  description: ConditionOperator specifies the operator
+                                    to match a value.
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - op
+                              - value
+                              type: object
+                            type: array
+                          fieldPath:
+                            description: FieldPath refers to the value of an object's
+                              field.
                             type: string
                           name:
-                            description: Name of the referenced object.
+                            description: Name is the unique name of a DataOutput in
+                              an ApplicationConfiguration.
                             type: string
-                          uid:
-                            description: UID of the referenced object.
-                            type: string
-                        required:
-                        - apiVersion
-                        - kind
-                        - name
                         type: object
-                    required:
-                    - from
-                    - to
-                    type: object
-                  type: array
-              type: object
-            workloads:
-              description: Workloads created by this ApplicationConfiguration.
-              items:
-                description: A WorkloadStatus represents the status of a workload.
+                      type: array
+                    parameterValues:
+                      description: ParameterValues specify values for the the specified
+                        component's parameters. Any parameter required by the component
+                        must be specified.
+                      items:
+                        description: A ComponentParameterValue specifies a value for
+                          a named parameter. The associated component must publish
+                          a parameter with this name.
+                        properties:
+                          name:
+                            description: Name of the component parameter to set.
+                            type: string
+                          value:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: Value to set.
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                    revisionName:
+                      description: RevisionName of a specific component revision to
+                        which to bind ApplicationConfiguration. This is mutually exclusive
+                        with componentName.
+                      type: string
+                    scopes:
+                      description: Scopes in which the specified component should
+                        exist.
+                      items:
+                        description: A ComponentScope specifies a scope in which a
+                          component should exist.
+                        properties:
+                          scopeRef:
+                            description: A ScopeReference must refer to an OAM scope
+                              resource.
+                            properties:
+                              apiVersion:
+                                description: APIVersion of the referenced object.
+                                type: string
+                              kind:
+                                description: Kind of the referenced object.
+                                type: string
+                              name:
+                                description: Name of the referenced object.
+                                type: string
+                              uid:
+                                description: UID of the referenced object.
+                                type: string
+                            required:
+                            - apiVersion
+                            - kind
+                            - name
+                            type: object
+                        required:
+                        - scopeRef
+                        type: object
+                      type: array
+                    traits:
+                      description: Traits of the specified component.
+                      items:
+                        description: A ComponentTrait specifies a trait that should
+                          be applied to a component.
+                        properties:
+                          dataInputs:
+                            description: DataInputs specify the data input sinks into
+                              this trait.
+                            items:
+                              description: DataInput specifies a data input sink to
+                                an object.
+                              properties:
+                                toFieldPaths:
+                                  description: ToFieldPaths specifies the field paths
+                                    of an object to fill passed value.
+                                  items:
+                                    type: string
+                                  type: array
+                                valueFrom:
+                                  description: ValueFrom specifies the value source.
+                                  properties:
+                                    dataOutputName:
+                                      description: DataOutputName matches a name of
+                                        a DataOutput in the same AppConfig.
+                                      type: string
+                                  required:
+                                  - dataOutputName
+                                  type: object
+                              type: object
+                            type: array
+                          dataOutputs:
+                            description: DataOutputs specify the data output sources
+                              from this trait.
+                            items:
+                              description: DataOutput specifies a data output source
+                                from an object.
+                              properties:
+                                conditions:
+                                  description: Conditions specify the conditions that
+                                    should be satisfied before emitting a data output.
+                                    Different conditions are AND-ed together. If no
+                                    conditions is specified, it is by default to check
+                                    output value not empty.
+                                  items:
+                                    description: ConditionRequirement specifies the
+                                      requirement to match a value.
+                                    properties:
+                                      fieldPath:
+                                        type: string
+                                      op:
+                                        description: ConditionOperator specifies the
+                                          operator to match a value.
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - op
+                                    - value
+                                    type: object
+                                  type: array
+                                fieldPath:
+                                  description: FieldPath refers to the value of an
+                                    object's field.
+                                  type: string
+                                name:
+                                  description: Name is the unique name of a DataOutput
+                                    in an ApplicationConfiguration.
+                                  type: string
+                              type: object
+                            type: array
+                          trait:
+                            description: A Trait that will be created for the component
+                            type: object
+                            x-kubernetes-embedded-resource: true
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - trait
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            required:
+            - components
+            type: object
+          status:
+            description: An ApplicationConfigurationStatus represents the observed
+              state of a ApplicationConfiguration.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              dependency:
+                description: DependencyStatus represents the observed state of the
+                  dependency of an ApplicationConfiguration.
                 properties:
-                  componentName:
-                    description: ComponentName that produced this workload.
-                    type: string
-                  componentRevisionName:
-                    description: ComponentRevisionName of current component
-                    type: string
-                  scopes:
-                    description: Scopes associated with this workload.
+                  unsatisfied:
                     items:
-                      description: A WorkloadScope represents a trait associated with
-                        a workload.
+                      description: UnstaifiedDependency describes unsatisfied dependency
+                        flow between one pair of objects.
                       properties:
-                        scopeRef:
-                          description: Reference to a scope created by an ApplicationConfiguration.
+                        from:
+                          description: DependencyFromObject represents the object
+                            that dependency data comes from.
                           properties:
                             apiVersion:
                               description: APIVersion of the referenced object.
+                              type: string
+                            fieldPath:
                               type: string
                             kind:
                               description: Kind of the referenced object.
@@ -401,22 +335,17 @@ spec:
                           - kind
                           - name
                           type: object
-                      required:
-                      - scopeRef
-                      type: object
-                    type: array
-                  traits:
-                    description: Traits associated with this workload.
-                    items:
-                      description: A WorkloadTrait represents a trait associated with
-                        a workload.
-                      properties:
-                        traitRef:
-                          description: Reference to a trait created by an ApplicationConfiguration.
+                        to:
+                          description: DependencyToObject represents the object that
+                            dependency data goes to.
                           properties:
                             apiVersion:
                               description: APIVersion of the referenced object.
                               type: string
+                            fieldPaths:
+                              items:
+                                type: string
+                              type: array
                             kind:
                               description: Kind of the referenced object.
                               type: string
@@ -432,40 +361,112 @@ spec:
                           - name
                           type: object
                       required:
-                      - traitRef
+                      - from
+                      - to
                       type: object
                     type: array
-                  workloadRef:
-                    description: Reference to a workload created by an ApplicationConfiguration.
-                    properties:
-                      apiVersion:
-                        description: APIVersion of the referenced object.
-                        type: string
-                      kind:
-                        description: Kind of the referenced object.
-                        type: string
-                      name:
-                        description: Name of the referenced object.
-                        type: string
-                      uid:
-                        description: UID of the referenced object.
-                        type: string
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                    type: object
                 type: object
-              type: array
-          required:
-          - dependency
-          type: object
-      type: object
-  version: v1alpha2
-  versions:
-  - name: v1alpha2
+              workloads:
+                description: Workloads created by this ApplicationConfiguration.
+                items:
+                  description: A WorkloadStatus represents the status of a workload.
+                  properties:
+                    componentName:
+                      description: ComponentName that produced this workload.
+                      type: string
+                    componentRevisionName:
+                      description: ComponentRevisionName of current component
+                      type: string
+                    scopes:
+                      description: Scopes associated with this workload.
+                      items:
+                        description: A WorkloadScope represents a trait associated
+                          with a workload.
+                        properties:
+                          scopeRef:
+                            description: Reference to a scope created by an ApplicationConfiguration.
+                            properties:
+                              apiVersion:
+                                description: APIVersion of the referenced object.
+                                type: string
+                              kind:
+                                description: Kind of the referenced object.
+                                type: string
+                              name:
+                                description: Name of the referenced object.
+                                type: string
+                              uid:
+                                description: UID of the referenced object.
+                                type: string
+                            required:
+                            - apiVersion
+                            - kind
+                            - name
+                            type: object
+                        required:
+                        - scopeRef
+                        type: object
+                      type: array
+                    traits:
+                      description: Traits associated with this workload.
+                      items:
+                        description: A WorkloadTrait represents a trait associated
+                          with a workload.
+                        properties:
+                          traitRef:
+                            description: Reference to a trait created by an ApplicationConfiguration.
+                            properties:
+                              apiVersion:
+                                description: APIVersion of the referenced object.
+                                type: string
+                              kind:
+                                description: Kind of the referenced object.
+                                type: string
+                              name:
+                                description: Name of the referenced object.
+                                type: string
+                              uid:
+                                description: UID of the referenced object.
+                                type: string
+                            required:
+                            - apiVersion
+                            - kind
+                            - name
+                            type: object
+                        required:
+                        - traitRef
+                        type: object
+                      type: array
+                    workloadRef:
+                      description: Reference to a workload created by an ApplicationConfiguration.
+                      properties:
+                        apiVersion:
+                          description: APIVersion of the referenced object.
+                          type: string
+                        kind:
+                          description: Kind of the referenced object.
+                          type: string
+                        name:
+                          description: Name of the referenced object.
+                          type: string
+                        uid:
+                          description: UID of the referenced object.
+                          type: string
+                      required:
+                      - apiVersion
+                      - kind
+                      - name
+                      type: object
+                  type: object
+                type: array
+            required:
+            - dependency
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_components.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_components.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,13 +8,6 @@ metadata:
   creationTimestamp: null
   name: components.core.oam.dev
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.workload.kind
-    name: WORKLOAD-KIND
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
   group: core.oam.dev
   names:
     categories:
@@ -25,125 +18,131 @@ spec:
     plural: components
     singular: component
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: A Component describes how an OAM workload kind may be instantiated.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: A ComponentSpec defines the desired state of a Component.
-          properties:
-            parameters:
-              description: Parameters exposed by this component. ApplicationConfigurations
-                that reference this component may specify values for these parameters,
-                which will in turn be injected into the embedded workload.
-              items:
-                description: A ComponentParameter defines a configurable parameter
-                  of a component.
-                properties:
-                  description:
-                    description: Description of this parameter.
-                    type: string
-                  fieldPaths:
-                    description: FieldPaths specifies an array of fields within this
-                      Component's workload that will be overwritten by the value of
-                      this parameter. The type of the parameter (e.g. int, string)
-                      is inferred from the type of these fields; All fields must be
-                      of the same type. Fields are specified as JSON field paths without
-                      a leading dot, for example 'spec.replicas'.
-                    items:
-                      type: string
-                    type: array
-                  name:
-                    description: Name of this parameter. OAM ApplicationConfigurations
-                      will specify parameter values using this name.
-                    type: string
-                  required:
-                    description: Required specifies whether or not a value for this
-                      parameter must be supplied when authoring an ApplicationConfiguration.
-                    type: boolean
-                required:
-                - fieldPaths
-                - name
-                type: object
-              type: array
-            workload:
-              description: A Workload that will be created for each ApplicationConfiguration
-                that includes this Component. Workloads must be defined by a WorkloadDefinition.
-              type: object
-              x-kubernetes-embedded-resource: true
-              x-kubernetes-preserve-unknown-fields: true
-          required:
-          - workload
-          type: object
-        status:
-          description: A ComponentStatus represents the observed state of a Component.
-          properties:
-            conditions:
-              description: Conditions of the resource.
-              items:
-                description: A Condition that may apply to a resource.
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time this condition
-                      transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A Message containing details about this condition's
-                      last transition from one status to another, if any.
-                    type: string
-                  reason:
-                    description: A Reason for this condition's last transition from
-                      one status to another.
-                    type: string
-                  status:
-                    description: Status of this condition; is it currently True, False,
-                      or Unknown?
-                    type: string
-                  type:
-                    description: Type of this condition. At most one of each condition
-                      type may apply to a resource at any point in time.
-                    type: string
-                required:
-                - lastTransitionTime
-                - reason
-                - status
-                - type
-                type: object
-              type: array
-            latestRevision:
-              description: LatestRevision of component
-              properties:
-                name:
-                  type: string
-                revision:
-                  format: int64
-                  type: integer
-              required:
-              - name
-              - revision
-              type: object
-          type: object
-      type: object
-  version: v1alpha2
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.workload.kind
+      name: WORKLOAD-KIND
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: A Component describes how an OAM workload kind may be instantiated.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: A ComponentSpec defines the desired state of a Component.
+            properties:
+              parameters:
+                description: Parameters exposed by this component. ApplicationConfigurations
+                  that reference this component may specify values for these parameters,
+                  which will in turn be injected into the embedded workload.
+                items:
+                  description: A ComponentParameter defines a configurable parameter
+                    of a component.
+                  properties:
+                    description:
+                      description: Description of this parameter.
+                      type: string
+                    fieldPaths:
+                      description: FieldPaths specifies an array of fields within
+                        this Component's workload that will be overwritten by the
+                        value of this parameter. The type of the parameter (e.g. int,
+                        string) is inferred from the type of these fields; All fields
+                        must be of the same type. Fields are specified as JSON field
+                        paths without a leading dot, for example 'spec.replicas'.
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: Name of this parameter. OAM ApplicationConfigurations
+                        will specify parameter values using this name.
+                      type: string
+                    required:
+                      description: Required specifies whether or not a value for this
+                        parameter must be supplied when authoring an ApplicationConfiguration.
+                      type: boolean
+                  required:
+                  - fieldPaths
+                  - name
+                  type: object
+                type: array
+              workload:
+                description: A Workload that will be created for each ApplicationConfiguration
+                  that includes this Component. Workloads must be defined by a WorkloadDefinition.
+                type: object
+                x-kubernetes-embedded-resource: true
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - workload
+            type: object
+          status:
+            description: A ComponentStatus represents the observed state of a Component.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              latestRevision:
+                description: LatestRevision of component
+                properties:
+                  name:
+                    type: string
+                  revision:
+                    format: int64
+                    type: integer
+                required:
+                - name
+                - revision
+                type: object
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_containerizedworkloads.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_containerizedworkloads.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -18,519 +18,521 @@ spec:
     plural: containerizedworkloads
     singular: containerizedworkload
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: A ContainerizedWorkload is a workload that runs OCI containers.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: A ContainerizedWorkloadSpec defines the desired state of a
-            ContainerizedWorkload.
-          properties:
-            arch:
-              description: CPUArchitecture required by this workload.
-              enum:
-              - i386
-              - amd64
-              - arm
-              - arm64
-              type: string
-            containers:
-              description: Containers of which this workload consists.
-              items:
-                description: A Container represents an Open Containers Initiative
-                  (OCI) container.
-                properties:
-                  args:
-                    description: Arguments to be passed to the command run by this
-                      container.
-                    items:
-                      type: string
-                    type: array
-                  command:
-                    description: Command to be run by this container.
-                    items:
-                      type: string
-                    type: array
-                  config:
-                    description: ConfigFiles that should be written within this container.
-                    items:
-                      description: A ContainerConfigFile specifies a configuration
-                        file that should be written within a container.
-                      properties:
-                        fromSecret:
-                          description: FromSecret is a secret key reference which
-                            can be used to assign a value to be written to the configuration
-                            file at the given path in the container.
-                          properties:
-                            key:
-                              description: The key to select.
-                              type: string
-                            name:
-                              description: The name of the secret.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                        path:
-                          description: Path within the container at which the configuration
-                            file should be written.
-                          type: string
-                        value:
-                          description: Value that should be written to the configuration
-                            file.
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    type: array
-                  env:
-                    description: Environment variables that should be set within this
-                      container.
-                    items:
-                      description: A ContainerEnvVar specifies an environment variable
-                        that should be set within a container.
-                      properties:
-                        fromSecret:
-                          description: FromSecret is a secret key reference which
-                            can be used to assign a value to the environment variable.
-                          properties:
-                            key:
-                              description: The key to select.
-                              type: string
-                            name:
-                              description: The name of the secret.
-                              type: string
-                          required:
-                          - key
-                          - name
-                          type: object
-                        name:
-                          description: Name of the environment variable. Must be composed
-                            of valid Unicode letter and number characters, as well
-                            as _ and -.
-                          pattern: ^[-_a-zA-Z0-9]+$
-                          type: string
-                        value:
-                          description: Value of the environment variable.
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  image:
-                    description: Image this container should run. Must be a path-like
-                      or URI-like representation of an OCI image. May be prefixed
-                      with a registry address and should be suffixed with a tag.
-                    type: string
-                  imagePullSecret:
-                    description: ImagePullSecret specifies the name of a Secret from
-                      which the credentials required to pull this container's image
-                      can be loaded.
-                    type: string
-                  livenessProbe:
-                    description: A LivenessProbe assesses whether this container is
-                      alive. Containers that fail liveness probes will be restarted.
-                    properties:
-                      exec:
-                        description: Exec probes a container's health by executing
-                          a command.
-                        properties:
-                          command:
-                            description: Command to be run by this probe.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - command
-                        type: object
-                      failureThreshold:
-                        description: FailureThreshold specifies how many consecutive
-                          probes must fail in order for the container to be considered
-                          healthy.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGet probes a container's health by sending
-                          an HTTP GET request.
-                        properties:
-                          httpHeaders:
-                            description: HTTPHeaders to send with the GET request.
-                            items:
-                              description: A HTTPHeader to be passed when probing
-                                a container.
-                              properties:
-                                name:
-                                  description: Name of this HTTP header. Must be unique
-                                    per probe.
-                                  type: string
-                                value:
-                                  description: Value of this HTTP header.
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to probe, e.g. '/healthz'.
-                            type: string
-                          port:
-                            description: Port to probe.
-                            format: int32
-                            type: integer
-                        required:
-                        - path
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: InitialDelaySeconds after a container starts
-                          before the first probe.
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: PeriodSeconds between probes.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: SuccessThreshold specifies how many consecutive
-                          probes must success in order for the container to be considered
-                          healthy.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: TCPSocketProbe probes a container's health by
-                          connecting to a TCP socket.
-                        properties:
-                          port:
-                            description: Port this probe should connect to.
-                            format: int32
-                            type: integer
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: TimeoutSeconds after which the probe times out.
-                        format: int32
-                        type: integer
-                    type: object
-                  name:
-                    description: Name of this container. Must be unique within its
-                      workload.
-                    type: string
-                  ports:
-                    description: Ports exposed by this container.
-                    items:
-                      description: A ContainerPort specifies a port that is exposed
-                        by a container.
-                      properties:
-                        containerPort:
-                          description: Port number. Must be unique within its container.
-                          format: int32
-                          type: integer
-                        name:
-                          description: Name of this port. Must be unique within its
-                            container. Must be lowercase alphabetical characters.
-                          pattern: ^[a-z]+$
-                          type: string
-                        protocol:
-                          description: Protocol used by the server listening on this
-                            port.
-                          enum:
-                          - TCP
-                          - UDP
-                          type: string
-                      required:
-                      - containerPort
-                      - name
-                      type: object
-                    type: array
-                  readinessProbe:
-                    description: A ReadinessProbe assesses whether this container
-                      is ready to serve requests. Containers that fail readiness probes
-                      will be withdrawn from service.
-                    properties:
-                      exec:
-                        description: Exec probes a container's health by executing
-                          a command.
-                        properties:
-                          command:
-                            description: Command to be run by this probe.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - command
-                        type: object
-                      failureThreshold:
-                        description: FailureThreshold specifies how many consecutive
-                          probes must fail in order for the container to be considered
-                          healthy.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGet probes a container's health by sending
-                          an HTTP GET request.
-                        properties:
-                          httpHeaders:
-                            description: HTTPHeaders to send with the GET request.
-                            items:
-                              description: A HTTPHeader to be passed when probing
-                                a container.
-                              properties:
-                                name:
-                                  description: Name of this HTTP header. Must be unique
-                                    per probe.
-                                  type: string
-                                value:
-                                  description: Value of this HTTP header.
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to probe, e.g. '/healthz'.
-                            type: string
-                          port:
-                            description: Port to probe.
-                            format: int32
-                            type: integer
-                        required:
-                        - path
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: InitialDelaySeconds after a container starts
-                          before the first probe.
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: PeriodSeconds between probes.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: SuccessThreshold specifies how many consecutive
-                          probes must success in order for the container to be considered
-                          healthy.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: TCPSocketProbe probes a container's health by
-                          connecting to a TCP socket.
-                        properties:
-                          port:
-                            description: Port this probe should connect to.
-                            format: int32
-                            type: integer
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: TimeoutSeconds after which the probe times out.
-                        format: int32
-                        type: integer
-                    type: object
-                  resources:
-                    description: Resources required by this container
-                    properties:
-                      cpu:
-                        description: CPU required by this container.
-                        properties:
-                          required:
-                            description: Required CPU count. 1.0 represents one CPU
-                              core.
-                            type: string
-                        required:
-                        - required
-                        type: object
-                      extended:
-                        description: Extended resources required by this container.
-                        items:
-                          description: ExtendedResource required by a container.
-                          properties:
-                            name:
-                              description: Name of the external resource. Resource
-                                names are specified in kind.group/version format,
-                                e.g. motionsensor.ext.example.com/v1.
-                              type: string
-                            required:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: Required extended resource(s), e.g. 8 or
-                                "very-cool-widget"
-                              x-kubernetes-int-or-string: true
-                          required:
-                          - name
-                          - required
-                          type: object
-                        type: array
-                      gpu:
-                        description: GPU required by this container.
-                        properties:
-                          required:
-                            description: Required GPU count.
-                            type: string
-                        required:
-                        - required
-                        type: object
-                      memory:
-                        description: Memory required by this container.
-                        properties:
-                          required:
-                            description: Required memory.
-                            type: string
-                        required:
-                        - required
-                        type: object
-                      volumes:
-                        description: Volumes required by this container.
-                        items:
-                          description: VolumeResource required by a container.
-                          properties:
-                            accessMode:
-                              description: AccessMode of this volume; RO (read only)
-                                or RW (read and write).
-                              enum:
-                              - RO
-                              - RW
-                              type: string
-                            disk:
-                              description: Disk requirements of this volume.
-                              properties:
-                                ephemeral:
-                                  description: Ephemeral specifies whether an external
-                                    disk needs to be mounted.
-                                  type: boolean
-                                required:
-                                  description: Required disk space.
-                                  type: string
-                              required:
-                              - required
-                              type: object
-                            mountPath:
-                              description: MouthPath at which this volume will be
-                                mounted within its container.
-                              type: string
-                            name:
-                              description: Name of this volume. Must be unique within
-                                its container.
-                              type: string
-                            sharingPolicy:
-                              description: SharingPolicy of this volume; Exclusive
-                                or Shared.
-                              enum:
-                              - Exclusive
-                              - Shared
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                    required:
-                    - cpu
-                    - memory
-                    type: object
-                required:
-                - image
-                - name
-                type: object
-              type: array
-            osType:
-              description: OperatingSystem required by this workload.
-              enum:
-              - linux
-              - windows
-              type: string
-          required:
-          - containers
-          type: object
-        status:
-          description: A ContainerizedWorkloadStatus represents the observed state
-            of a ContainerizedWorkload.
-          properties:
-            conditions:
-              description: Conditions of the resource.
-              items:
-                description: A Condition that may apply to a resource.
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time this condition
-                      transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A Message containing details about this condition's
-                      last transition from one status to another, if any.
-                    type: string
-                  reason:
-                    description: A Reason for this condition's last transition from
-                      one status to another.
-                    type: string
-                  status:
-                    description: Status of this condition; is it currently True, False,
-                      or Unknown?
-                    type: string
-                  type:
-                    description: Type of this condition. At most one of each condition
-                      type may apply to a resource at any point in time.
-                    type: string
-                required:
-                - lastTransitionTime
-                - reason
-                - status
-                - type
-                type: object
-              type: array
-            resources:
-              description: Resources managed by this containerised workload.
-              items:
-                description: A TypedReference refers to an object by Name, Kind, and
-                  APIVersion. It is commonly used to reference cluster-scoped objects
-                  or objects where the namespace is already known.
-                properties:
-                  apiVersion:
-                    description: APIVersion of the referenced object.
-                    type: string
-                  kind:
-                    description: Kind of the referenced object.
-                    type: string
-                  name:
-                    description: Name of the referenced object.
-                    type: string
-                  uid:
-                    description: UID of the referenced object.
-                    type: string
-                required:
-                - apiVersion
-                - kind
-                - name
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha2
   versions:
   - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: A ContainerizedWorkload is a workload that runs OCI containers.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: A ContainerizedWorkloadSpec defines the desired state of
+              a ContainerizedWorkload.
+            properties:
+              arch:
+                description: CPUArchitecture required by this workload.
+                enum:
+                - i386
+                - amd64
+                - arm
+                - arm64
+                type: string
+              containers:
+                description: Containers of which this workload consists.
+                items:
+                  description: A Container represents an Open Containers Initiative
+                    (OCI) container.
+                  properties:
+                    args:
+                      description: Arguments to be passed to the command run by this
+                        container.
+                      items:
+                        type: string
+                      type: array
+                    command:
+                      description: Command to be run by this container.
+                      items:
+                        type: string
+                      type: array
+                    config:
+                      description: ConfigFiles that should be written within this
+                        container.
+                      items:
+                        description: A ContainerConfigFile specifies a configuration
+                          file that should be written within a container.
+                        properties:
+                          fromSecret:
+                            description: FromSecret is a secret key reference which
+                              can be used to assign a value to be written to the configuration
+                              file at the given path in the container.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: The name of the secret.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          path:
+                            description: Path within the container at which the configuration
+                              file should be written.
+                            type: string
+                          value:
+                            description: Value that should be written to the configuration
+                              file.
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      type: array
+                    env:
+                      description: Environment variables that should be set within
+                        this container.
+                      items:
+                        description: A ContainerEnvVar specifies an environment variable
+                          that should be set within a container.
+                        properties:
+                          fromSecret:
+                            description: FromSecret is a secret key reference which
+                              can be used to assign a value to the environment variable.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: The name of the secret.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          name:
+                            description: Name of the environment variable. Must be
+                              composed of valid Unicode letter and number characters,
+                              as well as _ and -.
+                            pattern: ^[-_a-zA-Z0-9]+$
+                            type: string
+                          value:
+                            description: Value of the environment variable.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    image:
+                      description: Image this container should run. Must be a path-like
+                        or URI-like representation of an OCI image. May be prefixed
+                        with a registry address and should be suffixed with a tag.
+                      type: string
+                    imagePullSecret:
+                      description: ImagePullSecret specifies the name of a Secret
+                        from which the credentials required to pull this container's
+                        image can be loaded.
+                      type: string
+                    livenessProbe:
+                      description: A LivenessProbe assesses whether this container
+                        is alive. Containers that fail liveness probes will be restarted.
+                      properties:
+                        exec:
+                          description: Exec probes a container's health by executing
+                            a command.
+                          properties:
+                            command:
+                              description: Command to be run by this probe.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - command
+                          type: object
+                        failureThreshold:
+                          description: FailureThreshold specifies how many consecutive
+                            probes must fail in order for the container to be considered
+                            healthy.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet probes a container's health by sending
+                            an HTTP GET request.
+                          properties:
+                            httpHeaders:
+                              description: HTTPHeaders to send with the GET request.
+                              items:
+                                description: A HTTPHeader to be passed when probing
+                                  a container.
+                                properties:
+                                  name:
+                                    description: Name of this HTTP header. Must be
+                                      unique per probe.
+                                    type: string
+                                  value:
+                                    description: Value of this HTTP header.
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to probe, e.g. '/healthz'.
+                              type: string
+                            port:
+                              description: Port to probe.
+                              format: int32
+                              type: integer
+                          required:
+                          - path
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: InitialDelaySeconds after a container starts
+                            before the first probe.
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: PeriodSeconds between probes.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: SuccessThreshold specifies how many consecutive
+                            probes must success in order for the container to be considered
+                            healthy.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocketProbe probes a container's health
+                            by connecting to a TCP socket.
+                          properties:
+                            port:
+                              description: Port this probe should connect to.
+                              format: int32
+                              type: integer
+                          required:
+                          - port
+                          type: object
+                        timeoutSeconds:
+                          description: TimeoutSeconds after which the probe times
+                            out.
+                          format: int32
+                          type: integer
+                      type: object
+                    name:
+                      description: Name of this container. Must be unique within its
+                        workload.
+                      type: string
+                    ports:
+                      description: Ports exposed by this container.
+                      items:
+                        description: A ContainerPort specifies a port that is exposed
+                          by a container.
+                        properties:
+                          containerPort:
+                            description: Port number. Must be unique within its container.
+                            format: int32
+                            type: integer
+                          name:
+                            description: Name of this port. Must be unique within
+                              its container. Must be lowercase alphabetical characters.
+                            pattern: ^[a-z]+$
+                            type: string
+                          protocol:
+                            description: Protocol used by the server listening on
+                              this port.
+                            enum:
+                            - TCP
+                            - UDP
+                            type: string
+                        required:
+                        - containerPort
+                        - name
+                        type: object
+                      type: array
+                    readinessProbe:
+                      description: A ReadinessProbe assesses whether this container
+                        is ready to serve requests. Containers that fail readiness
+                        probes will be withdrawn from service.
+                      properties:
+                        exec:
+                          description: Exec probes a container's health by executing
+                            a command.
+                          properties:
+                            command:
+                              description: Command to be run by this probe.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - command
+                          type: object
+                        failureThreshold:
+                          description: FailureThreshold specifies how many consecutive
+                            probes must fail in order for the container to be considered
+                            healthy.
+                          format: int32
+                          type: integer
+                        httpGet:
+                          description: HTTPGet probes a container's health by sending
+                            an HTTP GET request.
+                          properties:
+                            httpHeaders:
+                              description: HTTPHeaders to send with the GET request.
+                              items:
+                                description: A HTTPHeader to be passed when probing
+                                  a container.
+                                properties:
+                                  name:
+                                    description: Name of this HTTP header. Must be
+                                      unique per probe.
+                                    type: string
+                                  value:
+                                    description: Value of this HTTP header.
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to probe, e.g. '/healthz'.
+                              type: string
+                            port:
+                              description: Port to probe.
+                              format: int32
+                              type: integer
+                          required:
+                          - path
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: InitialDelaySeconds after a container starts
+                            before the first probe.
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: PeriodSeconds between probes.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: SuccessThreshold specifies how many consecutive
+                            probes must success in order for the container to be considered
+                            healthy.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocketProbe probes a container's health
+                            by connecting to a TCP socket.
+                          properties:
+                            port:
+                              description: Port this probe should connect to.
+                              format: int32
+                              type: integer
+                          required:
+                          - port
+                          type: object
+                        timeoutSeconds:
+                          description: TimeoutSeconds after which the probe times
+                            out.
+                          format: int32
+                          type: integer
+                      type: object
+                    resources:
+                      description: Resources required by this container
+                      properties:
+                        cpu:
+                          description: CPU required by this container.
+                          properties:
+                            required:
+                              description: Required CPU count. 1.0 represents one
+                                CPU core.
+                              type: string
+                          required:
+                          - required
+                          type: object
+                        extended:
+                          description: Extended resources required by this container.
+                          items:
+                            description: ExtendedResource required by a container.
+                            properties:
+                              name:
+                                description: Name of the external resource. Resource
+                                  names are specified in kind.group/version format,
+                                  e.g. motionsensor.ext.example.com/v1.
+                                type: string
+                              required:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Required extended resource(s), e.g. 8
+                                  or "very-cool-widget"
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - name
+                            - required
+                            type: object
+                          type: array
+                        gpu:
+                          description: GPU required by this container.
+                          properties:
+                            required:
+                              description: Required GPU count.
+                              type: string
+                          required:
+                          - required
+                          type: object
+                        memory:
+                          description: Memory required by this container.
+                          properties:
+                            required:
+                              description: Required memory.
+                              type: string
+                          required:
+                          - required
+                          type: object
+                        volumes:
+                          description: Volumes required by this container.
+                          items:
+                            description: VolumeResource required by a container.
+                            properties:
+                              accessMode:
+                                description: AccessMode of this volume; RO (read only)
+                                  or RW (read and write).
+                                enum:
+                                - RO
+                                - RW
+                                type: string
+                              disk:
+                                description: Disk requirements of this volume.
+                                properties:
+                                  ephemeral:
+                                    description: Ephemeral specifies whether an external
+                                      disk needs to be mounted.
+                                    type: boolean
+                                  required:
+                                    description: Required disk space.
+                                    type: string
+                                required:
+                                - required
+                                type: object
+                              mountPath:
+                                description: MouthPath at which this volume will be
+                                  mounted within its container.
+                                type: string
+                              name:
+                                description: Name of this volume. Must be unique within
+                                  its container.
+                                type: string
+                              sharingPolicy:
+                                description: SharingPolicy of this volume; Exclusive
+                                  or Shared.
+                                enum:
+                                - Exclusive
+                                - Shared
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                      required:
+                      - cpu
+                      - memory
+                      type: object
+                  required:
+                  - image
+                  - name
+                  type: object
+                type: array
+              osType:
+                description: OperatingSystem required by this workload.
+                enum:
+                - linux
+                - windows
+                type: string
+            required:
+            - containers
+            type: object
+          status:
+            description: A ContainerizedWorkloadStatus represents the observed state
+              of a ContainerizedWorkload.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              resources:
+                description: Resources managed by this containerised workload.
+                items:
+                  description: A TypedReference refers to an object by Name, Kind,
+                    and APIVersion. It is commonly used to reference cluster-scoped
+                    objects or objects where the namespace is already known.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the referenced object.
+                      type: string
+                    kind:
+                      description: Kind of the referenced object.
+                      type: string
+                    name:
+                      description: Name of the referenced object.
+                      type: string
+                    uid:
+                      description: UID of the referenced object.
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  type: object
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_healthscopes.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_healthscopes.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,10 +8,6 @@ metadata:
   creationTimestamp: null
   name: healthscopes.core.oam.dev
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.health
-    name: HEALTH
-    type: string
   group: core.oam.dev
   names:
     categories:
@@ -22,111 +18,115 @@ spec:
     plural: healthscopes
     singular: healthscope
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: A HealthScope determines an aggregate health status based of the
-        health of components.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: A HealthScopeSpec defines the desired state of a HealthScope.
-          properties:
-            probe-interval:
-              description: ProbeInterval is the amount of time in seconds between
-                probing tries.
-              format: int32
-              type: integer
-            probe-timeout:
-              description: ProbeTimeout is the amount of time in seconds to wait when
-                receiving a response before marked failure.
-              format: int32
-              type: integer
-            workloadRefs:
-              description: WorkloadReferences to the workloads that are in this scope.
-              items:
-                description: A TypedReference refers to an object by Name, Kind, and
-                  APIVersion. It is commonly used to reference cluster-scoped objects
-                  or objects where the namespace is already known.
-                properties:
-                  apiVersion:
-                    description: APIVersion of the referenced object.
-                    type: string
-                  kind:
-                    description: Kind of the referenced object.
-                    type: string
-                  name:
-                    description: Name of the referenced object.
-                    type: string
-                  uid:
-                    description: UID of the referenced object.
-                    type: string
-                required:
-                - apiVersion
-                - kind
-                - name
-                type: object
-              type: array
-          type: object
-        status:
-          description: A HealthScopeStatus represents the observed state of a HealthScope.
-          properties:
-            conditions:
-              description: Conditions of the resource.
-              items:
-                description: A Condition that may apply to a resource.
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time this condition
-                      transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A Message containing details about this condition's
-                      last transition from one status to another, if any.
-                    type: string
-                  reason:
-                    description: A Reason for this condition's last transition from
-                      one status to another.
-                    type: string
-                  status:
-                    description: Status of this condition; is it currently True, False,
-                      or Unknown?
-                    type: string
-                  type:
-                    description: Type of this condition. At most one of each condition
-                      type may apply to a resource at any point in time.
-                    type: string
-                required:
-                - lastTransitionTime
-                - reason
-                - status
-                - type
-                type: object
-              type: array
-            health:
-              type: string
-          required:
-          - health
-          type: object
-      type: object
-  version: v1alpha2
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .status.health
+      name: HEALTH
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: A HealthScope determines an aggregate health status based of
+          the health of components.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: A HealthScopeSpec defines the desired state of a HealthScope.
+            properties:
+              probe-interval:
+                description: ProbeInterval is the amount of time in seconds between
+                  probing tries.
+                format: int32
+                type: integer
+              probe-timeout:
+                description: ProbeTimeout is the amount of time in seconds to wait
+                  when receiving a response before marked failure.
+                format: int32
+                type: integer
+              workloadRefs:
+                description: WorkloadReferences to the workloads that are in this
+                  scope.
+                items:
+                  description: A TypedReference refers to an object by Name, Kind,
+                    and APIVersion. It is commonly used to reference cluster-scoped
+                    objects or objects where the namespace is already known.
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the referenced object.
+                      type: string
+                    kind:
+                      description: Kind of the referenced object.
+                      type: string
+                    name:
+                      description: Name of the referenced object.
+                      type: string
+                    uid:
+                      description: UID of the referenced object.
+                      type: string
+                  required:
+                  - apiVersion
+                  - kind
+                  - name
+                  type: object
+                type: array
+            type: object
+          status:
+            description: A HealthScopeStatus represents the observed state of a HealthScope.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              health:
+                type: string
+            required:
+            - health
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_manualscalertraits.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_manualscalertraits.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -18,100 +18,100 @@ spec:
     plural: manualscalertraits
     singular: manualscalertrait
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: A ManualScalerTrait determines how many replicas a workload should
-        have.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: A ManualScalerTraitSpec defines the desired state of a ManualScalerTrait.
-          properties:
-            replicaCount:
-              description: ReplicaCount of the workload this trait applies to.
-              format: int32
-              type: integer
-            workloadRef:
-              description: WorkloadReference to the workload this trait applies to.
-              properties:
-                apiVersion:
-                  description: APIVersion of the referenced object.
-                  type: string
-                kind:
-                  description: Kind of the referenced object.
-                  type: string
-                name:
-                  description: Name of the referenced object.
-                  type: string
-                uid:
-                  description: UID of the referenced object.
-                  type: string
-              required:
-              - apiVersion
-              - kind
-              - name
-              type: object
-          required:
-          - replicaCount
-          - workloadRef
-          type: object
-        status:
-          description: A ManualScalerTraitStatus represents the observed state of
-            a ManualScalerTrait.
-          properties:
-            conditions:
-              description: Conditions of the resource.
-              items:
-                description: A Condition that may apply to a resource.
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time this condition
-                      transitioned from one status to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A Message containing details about this condition's
-                      last transition from one status to another, if any.
-                    type: string
-                  reason:
-                    description: A Reason for this condition's last transition from
-                      one status to another.
-                    type: string
-                  status:
-                    description: Status of this condition; is it currently True, False,
-                      or Unknown?
-                    type: string
-                  type:
-                    description: Type of this condition. At most one of each condition
-                      type may apply to a resource at any point in time.
-                    type: string
-                required:
-                - lastTransitionTime
-                - reason
-                - status
-                - type
-                type: object
-              type: array
-          type: object
-      type: object
-  version: v1alpha2
   versions:
   - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: A ManualScalerTrait determines how many replicas a workload should
+          have.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: A ManualScalerTraitSpec defines the desired state of a ManualScalerTrait.
+            properties:
+              replicaCount:
+                description: ReplicaCount of the workload this trait applies to.
+                format: int32
+                type: integer
+              workloadRef:
+                description: WorkloadReference to the workload this trait applies
+                  to.
+                properties:
+                  apiVersion:
+                    description: APIVersion of the referenced object.
+                    type: string
+                  kind:
+                    description: Kind of the referenced object.
+                    type: string
+                  name:
+                    description: Name of the referenced object.
+                    type: string
+                  uid:
+                    description: UID of the referenced object.
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+            required:
+            - replicaCount
+            - workloadRef
+            type: object
+          status:
+            description: A ManualScalerTraitStatus represents the observed state of
+              a ManualScalerTrait.
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition
+                        transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's
+                        last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from
+                        one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True,
+                        False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition
+                        type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_scopedefinitions.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_scopedefinitions.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,10 +8,6 @@ metadata:
   creationTimestamp: null
   name: scopedefinitions.core.oam.dev
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.definitionRef.name
-    name: DEFINITION-NAME
-    type: string
   group: core.oam.dev
   names:
     categories:
@@ -22,56 +18,60 @@ spec:
     plural: scopedefinitions
     singular: scopedefinition
   scope: Cluster
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: A ScopeDefinition registers a kind of Kubernetes custom resource
-        as a valid OAM scope kind by referencing its CustomResourceDefinition. The
-        CRD is used to validate the schema of the scope when it is embedded in an
-        OAM ApplicationConfiguration.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: A ScopeDefinitionSpec defines the desired state of a ScopeDefinition.
-          properties:
-            allowComponentOverlap:
-              description: AllowComponentOverlap specifies whether an OAM component
-                may exist in multiple instances of this kind of scope.
-              type: boolean
-            definitionRef:
-              description: Reference to the CustomResourceDefinition that defines
-                this scope kind.
-              properties:
-                name:
-                  description: Name of the referenced CustomResourceDefinition.
-                  type: string
-              required:
-              - name
-              type: object
-            extension:
-              description: Extension is used for extension needs by OAM platform builders
-              type: object
-          required:
-          - allowComponentOverlap
-          - definitionRef
-          type: object
-      type: object
-  version: v1alpha2
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.definitionRef.name
+      name: DEFINITION-NAME
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: A ScopeDefinition registers a kind of Kubernetes custom resource
+          as a valid OAM scope kind by referencing its CustomResourceDefinition. The
+          CRD is used to validate the schema of the scope when it is embedded in an
+          OAM ApplicationConfiguration.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: A ScopeDefinitionSpec defines the desired state of a ScopeDefinition.
+            properties:
+              allowComponentOverlap:
+                description: AllowComponentOverlap specifies whether an OAM component
+                  may exist in multiple instances of this kind of scope.
+                type: boolean
+              definitionRef:
+                description: Reference to the CustomResourceDefinition that defines
+                  this scope kind.
+                properties:
+                  name:
+                    description: Name of the referenced CustomResourceDefinition.
+                    type: string
+                required:
+                - name
+                type: object
+              extension:
+                description: Extension is used for extension needs by OAM platform
+                  builders
+                type: object
+            required:
+            - allowComponentOverlap
+            - definitionRef
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_traitdefinitions.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_traitdefinitions.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,10 +8,6 @@ metadata:
   creationTimestamp: null
   name: traitdefinitions.core.oam.dev
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.definitionRef.name
-    name: DEFINITION-NAME
-    type: string
   group: core.oam.dev
   names:
     categories:
@@ -22,67 +18,71 @@ spec:
     plural: traitdefinitions
     singular: traitdefinition
   scope: Cluster
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: A TraitDefinition registers a kind of Kubernetes custom resource
-        as a valid OAM trait kind by referencing its CustomResourceDefinition. The
-        CRD is used to validate the schema of the trait when it is embedded in an
-        OAM ApplicationConfiguration.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: A TraitDefinitionSpec defines the desired state of a TraitDefinition.
-          properties:
-            appliesToWorkloads:
-              description: AppliesToWorkloads specifies the list of workload kinds
-                this trait applies to. Workload kinds are specified in kind.group/version
-                format, e.g. server.core.oam.dev/v1alpha2. Traits that omit this field
-                apply to all workload kinds.
-              items:
-                type: string
-              type: array
-            definitionRef:
-              description: Reference to the CustomResourceDefinition that defines
-                this trait kind.
-              properties:
-                name:
-                  description: Name of the referenced CustomResourceDefinition.
-                  type: string
-              required:
-              - name
-              type: object
-            extension:
-              description: Extension is used for extension needs by OAM platform builders
-              type: object
-            revisionEnabled:
-              description: Revision indicates whether a trait is aware of component
-                revision
-              type: boolean
-            workloadRefPath:
-              description: WorkloadRefPath indicates where/if a trait accepts a workloadRef
-                object
-              type: string
-          required:
-          - definitionRef
-          type: object
-      type: object
-  version: v1alpha2
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.definitionRef.name
+      name: DEFINITION-NAME
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: A TraitDefinition registers a kind of Kubernetes custom resource
+          as a valid OAM trait kind by referencing its CustomResourceDefinition. The
+          CRD is used to validate the schema of the trait when it is embedded in an
+          OAM ApplicationConfiguration.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: A TraitDefinitionSpec defines the desired state of a TraitDefinition.
+            properties:
+              appliesToWorkloads:
+                description: AppliesToWorkloads specifies the list of workload kinds
+                  this trait applies to. Workload kinds are specified in kind.group/version
+                  format, e.g. server.core.oam.dev/v1alpha2. Traits that omit this
+                  field apply to all workload kinds.
+                items:
+                  type: string
+                type: array
+              definitionRef:
+                description: Reference to the CustomResourceDefinition that defines
+                  this trait kind.
+                properties:
+                  name:
+                    description: Name of the referenced CustomResourceDefinition.
+                    type: string
+                required:
+                - name
+                type: object
+              extension:
+                description: Extension is used for extension needs by OAM platform
+                  builders
+                type: object
+              revisionEnabled:
+                description: Revision indicates whether a trait is aware of component
+                  revision
+                type: boolean
+              workloadRefPath:
+                description: WorkloadRefPath indicates where/if a trait accepts a
+                  workloadRef object
+                type: string
+            required:
+            - definitionRef
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_workloaddefinitions.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_workloaddefinitions.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,10 +8,6 @@ metadata:
   creationTimestamp: null
   name: workloaddefinitions.core.oam.dev
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.definitionRef.name
-    name: DEFINITION-NAME
-    type: string
   group: core.oam.dev
   names:
     categories:
@@ -22,75 +18,79 @@ spec:
     plural: workloaddefinitions
     singular: workloaddefinition
   scope: Cluster
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: A WorkloadDefinition registers a kind of Kubernetes custom resource
-        as a valid OAM workload kind by referencing its CustomResourceDefinition.
-        The CRD is used to validate the schema of the workload when it is embedded
-        in an OAM Component.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: A WorkloadDefinitionSpec defines the desired state of a WorkloadDefinition.
-          properties:
-            childResourceKinds:
-              description: ChildResourceKinds are the list of GVK of the child resources
-                this workload generates
-              items:
-                description: A ChildResourceKind defines a child Kubernetes resource
-                  kind with a selector
-                properties:
-                  apiVersion:
-                    description: APIVersion of the child resource
-                    type: string
-                  kind:
-                    description: Kind of the child resource
-                    type: string
-                  selector:
-                    additionalProperties:
-                      type: string
-                    description: Selector to select the child resources that the workload
-                      wants to expose to traits
-                    type: object
-                required:
-                - apiVersion
-                - kind
-                type: object
-              type: array
-            definitionRef:
-              description: Reference to the CustomResourceDefinition that defines
-                this workload kind.
-              properties:
-                name:
-                  description: Name of the referenced CustomResourceDefinition.
-                  type: string
-              required:
-              - name
-              type: object
-            extension:
-              description: Extension is used for extension needs by OAM platform builders
-              type: object
-          required:
-          - definitionRef
-          type: object
-      type: object
-  version: v1alpha2
   versions:
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - jsonPath: .spec.definitionRef.name
+      name: DEFINITION-NAME
+      type: string
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: A WorkloadDefinition registers a kind of Kubernetes custom resource
+          as a valid OAM workload kind by referencing its CustomResourceDefinition.
+          The CRD is used to validate the schema of the workload when it is embedded
+          in an OAM Component.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: A WorkloadDefinitionSpec defines the desired state of a WorkloadDefinition.
+            properties:
+              childResourceKinds:
+                description: ChildResourceKinds are the list of GVK of the child resources
+                  this workload generates
+                items:
+                  description: A ChildResourceKind defines a child Kubernetes resource
+                    kind with a selector
+                  properties:
+                    apiVersion:
+                      description: APIVersion of the child resource
+                      type: string
+                    kind:
+                      description: Kind of the child resource
+                      type: string
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: Selector to select the child resources that the
+                        workload wants to expose to traits
+                      type: object
+                  required:
+                  - apiVersion
+                  - kind
+                  type: object
+                type: array
+              definitionRef:
+                description: Reference to the CustomResourceDefinition that defines
+                  this workload kind.
+                properties:
+                  name:
+                    description: Name of the referenced CustomResourceDefinition.
+                    type: string
+                required:
+                - name
+                type: object
+              extension:
+                description: Extension is used for extension needs by OAM platform
+                  builders
+                type: object
+            required:
+            - definitionRef
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
- Modify `crd:trivialVersions` tag to `crd:crdVersions=v1` in generate.go file.
- Regenerate the CRDs with version v1.

fixes #118 