### PR TITLE
Fix unstable e2e test of dependency engine

### DIFF
--- a/test/e2e-test/appconfig_dependency_test.go
+++ b/test/e2e-test/appconfig_dependency_test.go
@@ -204,7 +204,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 			func() error {
 				return k8sClient.Get(ctx, inFooKey, inFoo)
 			},
-			time.Second*15, time.Millisecond*500).Should(BeNil())
+			time.Second*60, time.Second*5).Should(BeNil())
 		By("Verify the appconfig's dependency is satisfied")
 		appconfig = &v1alpha2.ApplicationConfiguration{}
 		logf.Log.Info("Checking on appconfig", "Key", appconfigKey)
@@ -213,7 +213,7 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 				k8sClient.Get(ctx, appconfigKey, appconfig)
 				return appconfig.Status.Dependency.Unsatisfied
 			},
-			time.Second*15, time.Millisecond*500).Should(BeNil())
+			time.Second*60, time.Second*5).Should(BeNil())
 	}
 
 	It("trait depends on another trait", func() {


### PR DESCRIPTION
Because the instability of e2e test is mainly in these two places after the dependency conditions are satisfied:
1. the update of appconfig
2. the start of resource which accepts data.

So I expand Eventually's timeout and polling interval in these two places.

(By the way, I update CRD version to v1 instead of v1beta1.)