### PR TITLE
refine the oam helper util

### DIFF
--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	ctrl "sigs.k8s.io/controller-runtime"
-
 	cpv1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/davecgh/go-spew/spew"
 	plur "github.com/gertd/go-pluralize"
@@ -44,12 +42,14 @@ const (
 )
 
 const (
-	//ErrUpdateStatus is the eror while applying status.
+	//ErrUpdateStatus is the error while applying status.
 	ErrUpdateStatus = "cannot apply status"
 	//ErrLocateAppConfig is the error while locating parent application.
 	ErrLocateAppConfig = "cannot locate the parent application configuration to emit event to"
 	// ErrLocateWorkload is the error while locate the workload
 	ErrLocateWorkload = "cannot find the workload that the trait is referencing to"
+	// ErrFetchChildResources is the error while fetching workload child resources
+	ErrFetchChildResources = "failed to fetch workload child resources"
 )
 
 // A ConditionedObject is an Object type with condition field
@@ -82,29 +82,27 @@ func LocateParentAppConfig(ctx context.Context, client client.Client, oamObject 
 	return nil, errors.Errorf(ErrLocateAppConfig)
 }
 
-// FetchWorkload fetch the workload that a trait is reference to
+// FetchWorkload fetch the workload that a trait refers to
 func FetchWorkload(ctx context.Context, c client.Client, mLog logr.Logger, oamTrait oam.Trait) (
-	*unstructured.Unstructured, ctrl.Result, error) {
+	*unstructured.Unstructured, error) {
 	var workload unstructured.Unstructured
 	workloadRef := oamTrait.GetWorkloadReference()
 	if len(workloadRef.Kind) == 0 || len(workloadRef.APIVersion) == 0 || len(workloadRef.Name) == 0 {
 		err := errors.New("no workload reference")
 		mLog.Error(err, ErrLocateWorkload)
-		return nil, ReconcileWaitResult,
-			PatchCondition(ctx, c, oamTrait, cpv1alpha1.ReconcileError(errors.Wrap(err, ErrLocateWorkload)))
+		return nil, err
 	}
 	workload.SetAPIVersion(workloadRef.APIVersion)
 	workload.SetKind(workloadRef.Kind)
 	wn := client.ObjectKey{Name: workloadRef.Name, Namespace: oamTrait.GetNamespace()}
 	if err := c.Get(ctx, wn, &workload); err != nil {
 		mLog.Error(err, "Workload not find", "kind", workloadRef.Kind, "workload name", workloadRef.Name)
-		return nil, ReconcileWaitResult,
-			PatchCondition(ctx, c, oamTrait, cpv1alpha1.ReconcileError(errors.Wrap(err, ErrLocateWorkload)))
+		return nil, err
 	}
 	mLog.Info("Get the workload the trait is pointing to", "workload name", workload.GetName(),
 		"workload APIVersion", workload.GetAPIVersion(), "workload Kind", workload.GetKind(), "workload UID",
 		workload.GetUID())
-	return &workload, ctrl.Result{}, nil
+	return &workload, nil
 }
 
 // FetchScopeDefinition fetch corresponding scopeDefinition given a scope
@@ -175,7 +173,8 @@ func fetchChildResources(ctx context.Context, mLog logr.Logger, r client.Reader,
 			workload.GetUID())
 		if err := r.List(ctx, &crs, client.InNamespace(workload.GetNamespace()),
 			client.MatchingLabels(wcr.Selector)); err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("failed to list object %s.%s", crs.GetAPIVersion(), crs.GetKind()))
+			mLog.Error(err, "failed to list object", "api version", crs.GetAPIVersion(), "kind", crs.GetKind())
+			return nil, err
 		}
 		// pick the ones that is owned by the workload
 		for _, cr := range crs.Items {


### PR DESCRIPTION
- remove reconciler related logic from the helper lib
- move the common error string to the helper lib
- do not wrap errors returned from k8s api-server so the callers can switch based on the error type using apimachinery