### PR TITLE
dependency: support appending array in data input

### DIFF
--- a/apis/core/v1alpha2/core_types.go
+++ b/apis/core/v1alpha2/core_types.go
@@ -461,6 +461,7 @@ type DataOutput struct {
 }
 
 // DataInput specifies a data input sink to an object.
+// If input is array, it will be appended to the target field paths.
 type DataInput struct {
 	// ValueFrom specifies the value source.
 	ValueFrom DataInputValueFrom `json:"valueFrom,omitempty"`

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_applicationconfigurations.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_applicationconfigurations.yaml
@@ -62,6 +62,8 @@ spec:
                         component.
                       items:
                         description: DataInput specifies a data input sink to an object.
+                          If input is array, it will be appended to the target field
+                          paths.
                         properties:
                           toFieldPaths:
                             description: ToFieldPaths specifies the field paths of
@@ -192,7 +194,8 @@ spec:
                               this trait.
                             items:
                               description: DataInput specifies a data input sink to
-                                an object.
+                                an object. If input is array, it will be appended
+                                to the target field paths.
                               properties:
                                 toFieldPaths:
                                   description: ToFieldPaths specifies the field paths

--- a/examples/dependency/definition.yaml
+++ b/examples/dependency/definition.yaml
@@ -11,6 +11,7 @@ spec:
     singular: foo
   scope: Namespaced
   version: v1
+  preserveUnknownFields: true
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: WorkloadDefinition

--- a/examples/dependency/demo.yaml
+++ b/examples/dependency/demo.yaml
@@ -8,9 +8,15 @@ spec:
     kind: Foo
     metadata:
       name: source
-## Uncomment the following and apply again will make dependency satisfied.
-# status:
-#   key: test
+    # Uncomment the following and apply again will make dependency satisfied.
+    # status:
+    #   key: test
+    status:
+      key:
+        - name: a
+          value: aa
+        - name: b
+          value: bb
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: Component
@@ -22,6 +28,10 @@ spec:
     kind: Foo
     metadata:
       name: sink
+    spec:
+      key:
+        - name: exist
+          value: existtt
 ---
 apiVersion: core.oam.dev/v1alpha2
 kind: ApplicationConfiguration
@@ -31,11 +41,11 @@ spec:
   components:
     - componentName: source
       dataOutputs:
-      - name: example-key
-        fieldPath: "status.key"
+        - name: example-key
+          fieldPath: "status.key"
     - componentName: sink
       dataInputs:
-      - valueFrom:
-          dataOutputName: example-key
-        toFieldPaths:
-        - "spec.key"
+        - valueFrom:
+            dataOutputName: example-key
+          toFieldPaths:
+            - "spec.key"

--- a/pkg/controller/v1alpha2/applicationconfiguration/applicationconfiguration_test.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/applicationconfiguration_test.go
@@ -677,6 +677,16 @@ func TestDependency(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	readyWorkloadArrayField := unreadyWorkload.DeepCopy()
+	err = unstructured.SetNestedStringSlice(readyWorkloadArrayField.Object, []string{"a"}, "spec", "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = unstructured.SetNestedStringSlice(readyWorkloadArrayField.Object, []string{"b"}, "status", "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	unreadyTrait := &unstructured.Unstructured{}
 	unreadyTrait.SetAPIVersion("v1")
 	unreadyTrait.SetKind("Trait")
@@ -719,8 +729,8 @@ func TestDependency(t *testing.T) {
 						FieldPath: "status.key",
 					}},
 				}},
-				wl:    unreadyWorkload,
-				trait: unreadyTrait,
+				wl:    unreadyWorkload.DeepCopy(),
+				trait: unreadyTrait.DeepCopy(),
 			},
 			want: want{
 				verifyWorkloads: func(ws []Workload) {
@@ -765,13 +775,21 @@ func TestDependency(t *testing.T) {
 						FieldPath: "status.key",
 					}},
 				}},
-				wl:    readyWorkload,
-				trait: unreadyTrait,
+				wl:    readyWorkload.DeepCopy(),
+				trait: unreadyTrait.DeepCopy(),
 			},
 			want: want{
 				verifyWorkloads: func(ws []Workload) {
 					if ws[0].HasDep {
 						t.Error("Workload should be ready to apply")
+					}
+
+					s, _, err := unstructured.NestedString(ws[0].Workload.UnstructuredContent(), "spec", "key")
+					if err != nil {
+						t.Fatal(err)
+					}
+					if diff := cmp.Diff(s, "test"); diff != "" {
+						t.Fatal(diff)
 					}
 				},
 				depStatus: &v1alpha2.DependencyStatus{},
@@ -793,8 +811,8 @@ func TestDependency(t *testing.T) {
 						}},
 					}},
 				}},
-				wl:    unreadyWorkload,
-				trait: unreadyTrait,
+				wl:    unreadyWorkload.DeepCopy(),
+				trait: unreadyTrait.DeepCopy(),
 			},
 			want: want{
 				verifyWorkloads: func(ws []Workload) {
@@ -840,13 +858,21 @@ func TestDependency(t *testing.T) {
 						}},
 					}},
 				}},
-				wl:    unreadyWorkload,
-				trait: readyTrait,
+				wl:    unreadyWorkload.DeepCopy(),
+				trait: readyTrait.DeepCopy(),
 			},
 			want: want{
 				verifyWorkloads: func(ws []Workload) {
 					if ws[0].HasDep {
 						t.Error("Workload should be ready to apply")
+					}
+
+					s, _, err := unstructured.NestedString(ws[0].Workload.UnstructuredContent(), "spec", "key")
+					if err != nil {
+						t.Fatal(err)
+					}
+					if diff := cmp.Diff(s, "test"); diff != "" {
+						t.Fatal(diff)
 					}
 				},
 				depStatus: &v1alpha2.DependencyStatus{},
@@ -870,8 +896,8 @@ func TestDependency(t *testing.T) {
 						FieldPath: "status.key",
 					}},
 				}},
-				wl:    unreadyWorkload,
-				trait: unreadyTrait,
+				wl:    unreadyWorkload.DeepCopy(),
+				trait: unreadyTrait.DeepCopy(),
 			},
 			want: want{
 				verifyWorkloads: func(ws []Workload) {
@@ -919,19 +945,27 @@ func TestDependency(t *testing.T) {
 						FieldPath: "status.key",
 					}},
 				}},
-				wl:    readyWorkload,
-				trait: unreadyTrait,
+				wl:    readyWorkload.DeepCopy(),
+				trait: unreadyTrait.DeepCopy(),
 			},
 			want: want{
 				verifyWorkloads: func(ws []Workload) {
 					if ws[0].Traits[0].HasDep {
 						t.Error("Trait should be ready to apply")
 					}
+
+					s, _, err := unstructured.NestedString(ws[0].Traits[0].Object.UnstructuredContent(), "spec", "key")
+					if err != nil {
+						t.Fatal(err)
+					}
+					if diff := cmp.Diff(s, "test"); diff != "" {
+						t.Fatal(diff)
+					}
 				},
 				depStatus: &v1alpha2.DependencyStatus{},
 			},
 		},
-		"Trait depends on another unreadyTrait that's unready": {
+		"Trait depends on another Trait that's unready": {
 			args: args{
 				components: []v1alpha2.ApplicationConfigurationComponent{{
 					ComponentName: "test-component-sink",
@@ -949,8 +983,8 @@ func TestDependency(t *testing.T) {
 						}},
 					}},
 				}},
-				wl:    unreadyWorkload,
-				trait: unreadyTrait,
+				wl:    unreadyWorkload.DeepCopy(),
+				trait: unreadyTrait.DeepCopy(),
 			},
 			want: want{
 				verifyWorkloads: func(ws []Workload) {
@@ -980,7 +1014,7 @@ func TestDependency(t *testing.T) {
 				},
 			},
 		},
-		"Trait depends on another unreadyTrait that's ready": {
+		"Trait depends on another Trait that's ready": {
 			args: args{
 				components: []v1alpha2.ApplicationConfigurationComponent{{
 					ComponentName: "test-component-sink",
@@ -998,13 +1032,21 @@ func TestDependency(t *testing.T) {
 						}},
 					}},
 				}},
-				wl:    unreadyWorkload,
-				trait: readyTrait,
+				wl:    unreadyWorkload.DeepCopy(),
+				trait: readyTrait.DeepCopy(),
 			},
 			want: want{
 				verifyWorkloads: func(ws []Workload) {
 					if ws[0].Traits[0].HasDep {
 						t.Error("Trait should be ready to apply")
+					}
+
+					s, _, err := unstructured.NestedString(ws[0].Traits[0].Object.UnstructuredContent(), "spec", "key")
+					if err != nil {
+						t.Fatal(err)
+					}
+					if diff := cmp.Diff(s, "test"); diff != "" {
+						t.Fatal(diff)
 					}
 				},
 				depStatus: &v1alpha2.DependencyStatus{},
@@ -1018,12 +1060,46 @@ func TestDependency(t *testing.T) {
 						ToFieldPaths: []string{"spec.key"},
 					}},
 				}},
-				wl:    unreadyWorkload,
-				trait: unreadyTrait,
+				wl:    unreadyWorkload.DeepCopy(),
+				trait: unreadyTrait.DeepCopy(),
 			},
 			want: want{
 				err: ErrDataOutputNotExist,
 			},
+		},
+		"DataInput of array type should append": {
+			args: args{
+				components: []v1alpha2.ApplicationConfigurationComponent{{
+					ComponentName: "test-component-sink",
+					DataInputs: []v1alpha2.DataInput{{
+						ValueFrom:    v1alpha2.DataInputValueFrom{DataOutputName: "test-output"},
+						ToFieldPaths: []string{"spec.key"},
+					}},
+				}, {
+					ComponentName: "test-component-source",
+					DataOutputs: []v1alpha2.DataOutput{{
+						Name:      "test-output",
+						FieldPath: "status.key",
+					}},
+				}},
+				wl:    readyWorkloadArrayField.DeepCopy(),
+				trait: unreadyTrait.DeepCopy(),
+			},
+			want: want{
+				verifyWorkloads: func(ws []Workload) {
+					if ws[0].HasDep {
+						t.Error("Workload should be ready to apply")
+					}
+
+					l, _, err := unstructured.NestedStringSlice(ws[0].Workload.UnstructuredContent(), "spec", "key")
+					if err != nil {
+						t.Fatal(err)
+					}
+					if diff := cmp.Diff(l, []string{"a", "b"}); diff != "" {
+						t.Fatal(diff)
+					}
+				},
+				depStatus: &v1alpha2.DependencyStatus{}},
 		},
 	}
 


### PR DESCRIPTION
fix https://github.com/crossplane/oam-kubernetes-runtime/issues/167

With this PR, the dependency engine can now take array in data input as well:


<details>
<summary>Click to toggle the example AppConfig:</summary>

```yaml
apiVersion: core.oam.dev/v1alpha2
kind: Component
metadata:
  name: source
spec:
  workload:
    apiVersion: example.com/v1
    kind: Foo
    metadata:
      name: source
    status:
      key:
        - name: a
          value: aa
        - name: b
          value: bb
---
apiVersion: core.oam.dev/v1alpha2
kind: Component
metadata:
  name: sink
spec:
  workload:
    apiVersion: example.com/v1
    kind: Foo
    metadata:
      name: sink
    spec:
      key:
        - name: exist
          value: existtt
---
apiVersion: core.oam.dev/v1alpha2
kind: ApplicationConfiguration
metadata:
  name: example-appconfig
spec:
  components:
    - componentName: source
      dataOutputs:
        - name: example-key
          fieldPath: "status.key"
    - componentName: sink
      dataInputs:
        - valueFrom:
            dataOutputName: example-key
          toFieldPaths:
            - "spec.key"
```
</details>

<details>
<summary>Click to toggle the result</summary>

```yaml
apiVersion: example.com/v1
kind: Foo
metadata:
  name: sink
  ownerReferences:
  - apiVersion: core.oam.dev/v1alpha2
    blockOwnerDeletion: true
    controller: true
    kind: ApplicationConfiguration
    name: example-appconfig
spec:
  key:
  - name: exist
    value: existtt
  - name: a
    value: aa
  - name: b
    value: bb
```
</details>

I will test with user scenarios first before removing WIP.