### PR TITLE
fix e2e-test failure of appconfig_finalizer

### DIFF
--- a/test/e2e-test/appconfig_finalizer_test.go
+++ b/test/e2e-test/appconfig_finalizer_test.go
@@ -214,8 +214,8 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 			}, time.Second*30, time.Millisecond*500).Should(Equal(0))
 
 			By("Check AppConfig has been deleted successfully")
-			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: appConfigName}, &appConfig)).
-				ShouldNot(Succeed())
+			Eventually(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: appConfigName}, &appConfig),
+				time.Second*15, time.Microsecond*500).Should(&util.NotFoundMatcher{})
 		})
 
 	})


### PR DESCRIPTION
Use `Eventually` to assert Delete AppConfig successfully.

Signed-off-by: roy wang <seiwy2010@gmail.com>