### PR TITLE
add oam default labels for trait

### DIFF
--- a/pkg/controller/v1alpha2/applicationconfiguration/applicationconfiguration.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/applicationconfiguration.go
@@ -323,7 +323,7 @@ func (r *OAMApplicationReconciler) updateStatus(ctx context.Context, ac *v1alpha
 		var ul unstructured.UnstructuredList
 		ul.SetKind(w.Workload.GetKind())
 		ul.SetAPIVersion(w.Workload.GetAPIVersion())
-		if err := r.client.List(ctx, &ul, client.MatchingLabels{oam.LabelAppName: ac.Name, oam.LabelAppComponent: w.ComponentName}); err != nil {
+		if err := r.client.List(ctx, &ul, client.MatchingLabels{oam.LabelAppName: ac.Name, oam.LabelAppComponent: w.ComponentName, oam.LabelOAMResourceType: oam.ResourceTypeWorkload}); err != nil {
 			continue
 		}
 		for _, v := range ul.Items {

--- a/pkg/controller/v1alpha2/applicationconfiguration/render.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/render.go
@@ -135,6 +135,7 @@ func (r *components) renderComponent(ctx context.Context, acc v1alpha2.Applicati
 		oam.LabelAppName:              ac.Name,
 		oam.LabelAppComponent:         acc.ComponentName,
 		oam.LabelAppComponentRevision: componentRevisionName,
+		oam.LabelOAMResourceType:      oam.ResourceTypeWorkload,
 	}
 	util.AddLabels(w, compInfoLabels)
 
@@ -147,12 +148,13 @@ func (r *components) renderComponent(ctx context.Context, acc v1alpha2.Applicati
 
 	traits := make([]*Trait, 0, len(acc.Traits))
 	traitDefs := make([]v1alpha2.TraitDefinition, 0, len(acc.Traits))
+	compInfoLabels[oam.LabelOAMResourceType] = oam.ResourceTypeTrait
 	for _, ct := range acc.Traits {
 		t, traitDef, err := r.renderTrait(ctx, ct, ac, acc.ComponentName, ref, dag)
 		if err != nil {
 			return nil, err
 		}
-
+		util.AddLabels(t, compInfoLabels)
 		// pass through labels and annotation from app-config to trait
 		util.PassLabelAndAnnotation(ac, t)
 		traits = append(traits, &Trait{Object: *t})

--- a/pkg/controller/v1alpha2/applicationconfiguration/render_test.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/render_test.go
@@ -199,6 +199,7 @@ func TestRenderComponents(t *testing.T) {
 								oam.LabelAppComponent:         componentName,
 								oam.LabelAppName:              acName,
 								oam.LabelAppComponentRevision: "",
+								oam.LabelOAMResourceType:      oam.ResourceTypeWorkload,
 							})
 							return w
 						}(),
@@ -208,6 +209,12 @@ func TestRenderComponents(t *testing.T) {
 								t.SetNamespace(namespace)
 								t.SetName(traitName)
 								t.SetOwnerReferences([]metav1.OwnerReference{*ref})
+								t.SetLabels(map[string]string{
+									oam.LabelAppComponent:         componentName,
+									oam.LabelAppName:              acName,
+									oam.LabelAppComponentRevision: "",
+									oam.LabelOAMResourceType:      oam.ResourceTypeTrait,
+								})
 								return &Trait{Object: *t}
 							}(),
 						},
@@ -267,6 +274,7 @@ func TestRenderComponents(t *testing.T) {
 								oam.LabelAppComponent:         componentName,
 								oam.LabelAppName:              acName,
 								oam.LabelAppComponentRevision: revisionName,
+								oam.LabelOAMResourceType:      oam.ResourceTypeWorkload,
 							})
 							return w
 						}(),
@@ -276,6 +284,12 @@ func TestRenderComponents(t *testing.T) {
 								t.SetNamespace(namespace)
 								t.SetName(traitName)
 								t.SetOwnerReferences([]metav1.OwnerReference{*ref})
+								t.SetLabels(map[string]string{
+									oam.LabelAppComponent:         componentName,
+									oam.LabelAppName:              acName,
+									oam.LabelAppComponentRevision: revisionName,
+									oam.LabelOAMResourceType:      oam.ResourceTypeTrait,
+								})
 								return &Trait{Object: *t}
 							}(),
 						},
@@ -326,6 +340,7 @@ func TestRenderComponents(t *testing.T) {
 								oam.LabelAppComponent:         componentName,
 								oam.LabelAppName:              acName,
 								oam.LabelAppComponentRevision: revisionName2,
+								oam.LabelOAMResourceType:      oam.ResourceTypeWorkload,
 							})
 							return w
 						}(),
@@ -335,6 +350,12 @@ func TestRenderComponents(t *testing.T) {
 								t.SetNamespace(namespace)
 								t.SetName(traitName)
 								t.SetOwnerReferences([]metav1.OwnerReference{*ref})
+								t.SetLabels(map[string]string{
+									oam.LabelAppComponent:         componentName,
+									oam.LabelAppName:              acName,
+									oam.LabelAppComponentRevision: revisionName2,
+									oam.LabelOAMResourceType:      oam.ResourceTypeTrait,
+								})
 								return &Trait{Object: *t}
 							}(),
 						},

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -25,4 +25,13 @@ const (
 	LabelAppComponent = "app.oam.dev/component"
 	// LabelAppComponentRevision records the revision name of Component
 	LabelAppComponentRevision = "app.oam.dev/revision"
+	// LabelOAMResourceType whether a CR is workload or trait
+	LabelOAMResourceType = "app.oam.dev/resourceType"
+)
+
+const (
+	// ResourceTypeTrait mark this K8s Custom Resource is an OAM trait
+	ResourceTypeTrait = "TRAIT"
+	// ResourceTypeWorkload mark this K8s Custom Resource is an OAM workload
+	ResourceTypeWorkload = "WORKLOAD"
 )

--- a/test/e2e-test/containerized_workload_test.go
+++ b/test/e2e-test/containerized_workload_test.go
@@ -200,13 +200,27 @@ var _ = Describe("ContainerizedWorkload", func() {
 			return k8sClient.Get(ctx, client.ObjectKey{Name: workloadInstanceName, Namespace: namespace}, cw)
 		}, time.Second*15, time.Millisecond*500).Should(BeNil())
 
-		By("Checking lables")
+		By("Checking ManuelScalerTrait is created")
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKey{Name: mts.Name, Namespace: namespace}, &mts)
+		}, time.Second*15, time.Millisecond*500).Should(BeNil())
+
+		By("Checking labels")
 		cwLabels := cw.GetLabels()
 		Expect(cwLabels).Should(SatisfyAll(
 			HaveKey(fakeLabelKey), // propogated from appConfig
 			HaveKey(oam.LabelAppComponent),
 			HaveKey(oam.LabelAppComponentRevision),
-			HaveKey(oam.LabelAppName)))
+			HaveKey(oam.LabelAppName),
+			HaveKey(oam.LabelOAMResourceType)))
+
+		cwLabels = mts.GetLabels()
+		Expect(cwLabels).Should(SatisfyAll(
+			HaveKey(fakeLabelKey), // propogated from appConfig
+			HaveKey(oam.LabelAppComponent),
+			HaveKey(oam.LabelAppComponentRevision),
+			HaveKey(oam.LabelAppName),
+			HaveKey(oam.LabelOAMResourceType)))
 
 		By("Checking deployment is created")
 		objectKey := client.ObjectKey{


### PR DESCRIPTION
Along with PR #189 

Add following labels as default OAM labels for all OAM workloads and traits.

```
metadata:
  labels:
    app.oam.dev/name: myapp
    app.oam.dev/component: mycomp
    app.oam.dev/revision: mycomp-v1
```