### PR TITLE
Fix helm chart template format issues

### DIFF
--- a/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
+++ b/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
@@ -123,15 +123,15 @@ spec:
             secretName: {{ .Values.certificate.secretName | quote }}
       {{ end }}
       terminationGracePeriodSeconds: 10
-    {{- with .Values.nodeSelector }}
-    nodeSelector:
-      {{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-    affinity:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-    tolerations:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
`nodeSelector` should be a member of `spec.template.spec`, not `spec.template`.

The error reported by Helm is:
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template): unknown field "nodeSelector" in io.k8s.api.core.v1.PodTemplateSpec
```

`affinity` and `tolerations` have similar problems :(