### PR TITLE
fix status automatically removed bug

### DIFF
--- a/apis/core/v1alpha2/core_types.go
+++ b/apis/core/v1alpha2/core_types.go
@@ -371,7 +371,7 @@ type WorkloadStatus struct {
 	Status string `json:"status,omitempty"`
 
 	// HistoryWorkingRevision is a flag showing if it's history revision but still working
-	HistoryWorkingRevision bool `json:"currentWorkingRevision,omitempty"`
+	HistoryWorkingRevision bool `json:"historyWorkingRevision,omitempty"`
 
 	// ComponentName that produced this workload.
 	ComponentName string `json:"componentName,omitempty"`
@@ -401,7 +401,7 @@ type ApplicationConfigurationStatus struct {
 	// if it needs a single place to summarize the status of the entire application
 	Status ApplicationStatus `json:"status,omitempty"`
 
-	Dependency DependencyStatus `json:"dependency"`
+	Dependency DependencyStatus `json:"dependency,omitempty"`
 
 	// Workloads created by this ApplicationConfiguration.
 	Workloads []WorkloadStatus `json:"workloads,omitempty"`

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_applicationconfigurations.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_applicationconfigurations.yaml
@@ -385,7 +385,7 @@ spec:
                     componentRevisionName:
                       description: ComponentRevisionName of current component
                       type: string
-                    currentWorkingRevision:
+                    historyWorkingRevision:
                       description: HistoryWorkingRevision is a flag showing if it's
                         history revision but still working
                       type: boolean
@@ -486,8 +486,6 @@ spec:
                       type: object
                   type: object
                 type: array
-            required:
-            - dependency
             type: object
         type: object
     served: true

--- a/charts/oam-kubernetes-runtime/values.yaml.tmpl
+++ b/charts/oam-kubernetes-runtime/values.yaml.tmpl
@@ -7,7 +7,7 @@ useWebhook: false
 image:
   repository: crossplane/oam-kubernetes-runtime
   tag: %%VERSION%%
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/oam-kubernetes-runtime/values.yaml.tmpl
+++ b/charts/oam-kubernetes-runtime/values.yaml.tmpl
@@ -7,7 +7,7 @@ useWebhook: false
 image:
   repository: crossplane/oam-kubernetes-runtime
   tag: %%VERSION%%
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 imagePullSecrets: []
 nameOverride: ""

--- a/pkg/controller/v1alpha2/applicationconfiguration/applicationconfiguration_test.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/applicationconfiguration_test.go
@@ -1394,3 +1394,192 @@ func TestAddDataOutputsToDAG(t *testing.T) {
 		t.Errorf("didn't add conditions to source correctly: %s", diff)
 	}
 }
+
+func TestPatchExtraField(t *testing.T) {
+	tests := map[string]struct {
+		acStatus      *v1alpha2.ApplicationConfigurationStatus
+		acPatchStatus v1alpha2.ApplicationConfigurationStatus
+		wantedStatus  *v1alpha2.ApplicationConfigurationStatus
+	}{
+		"patch extra": {
+			acStatus: &v1alpha2.ApplicationConfigurationStatus{
+				Workloads: []v1alpha2.WorkloadStatus{
+					{
+						HistoryWorkingRevision: false,
+						ComponentName:          "test",
+						ComponentRevisionName:  "test-v1",
+						Traits: []v1alpha2.WorkloadTrait{
+							{
+								Reference: runtimev1alpha1.TypedReference{
+									APIVersion: "apiVersion1",
+									Kind:       "kind1",
+									Name:       "trait1",
+								},
+							},
+						},
+					},
+				},
+			},
+			acPatchStatus: v1alpha2.ApplicationConfigurationStatus{
+				Workloads: []v1alpha2.WorkloadStatus{
+					{
+						Status:                "we need to add this",
+						ComponentRevisionName: "test-v1",
+						Traits: []v1alpha2.WorkloadTrait{
+							{
+								Status: "add this too",
+								Reference: runtimev1alpha1.TypedReference{
+									APIVersion: "apiVersion1",
+									Kind:       "kind1",
+									Name:       "trait1",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantedStatus: &v1alpha2.ApplicationConfigurationStatus{
+				Workloads: []v1alpha2.WorkloadStatus{
+					{
+						Status:                 "we need to add this",
+						HistoryWorkingRevision: false,
+						ComponentName:          "test",
+						ComponentRevisionName:  "test-v1",
+						Traits: []v1alpha2.WorkloadTrait{
+							{
+								Status: "add this too",
+								Reference: runtimev1alpha1.TypedReference{
+									APIVersion: "apiVersion1",
+									Kind:       "kind1",
+									Name:       "trait1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"patch trait mismatch": {
+			acStatus: &v1alpha2.ApplicationConfigurationStatus{
+				Workloads: []v1alpha2.WorkloadStatus{
+					{
+						HistoryWorkingRevision: false,
+						ComponentName:          "test",
+						ComponentRevisionName:  "test-v1",
+						Traits: []v1alpha2.WorkloadTrait{
+							{
+								Reference: runtimev1alpha1.TypedReference{
+									APIVersion: "apiVersion1",
+									Kind:       "kind1",
+									Name:       "trait1",
+								},
+							},
+						},
+					},
+				},
+			},
+			acPatchStatus: v1alpha2.ApplicationConfigurationStatus{
+				Workloads: []v1alpha2.WorkloadStatus{
+					{
+						Status:                "we need to add this",
+						ComponentRevisionName: "test-v1",
+						Traits: []v1alpha2.WorkloadTrait{
+							{
+								Status: "add this too",
+								Reference: runtimev1alpha1.TypedReference{
+									APIVersion: "apiVersion1",
+									Kind:       "kind1",
+									Name:       "trait2",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantedStatus: &v1alpha2.ApplicationConfigurationStatus{
+				Workloads: []v1alpha2.WorkloadStatus{
+					{
+						Status:                 "we need to add this",
+						HistoryWorkingRevision: false,
+						ComponentName:          "test",
+						ComponentRevisionName:  "test-v1",
+						Traits: []v1alpha2.WorkloadTrait{
+							{
+								Reference: runtimev1alpha1.TypedReference{
+									APIVersion: "apiVersion1",
+									Kind:       "kind1",
+									Name:       "trait1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"patch workload revision mismatch": {
+			acStatus: &v1alpha2.ApplicationConfigurationStatus{
+				Workloads: []v1alpha2.WorkloadStatus{
+					{
+						HistoryWorkingRevision: false,
+						ComponentName:          "test",
+						ComponentRevisionName:  "test-v1",
+						Traits: []v1alpha2.WorkloadTrait{
+							{
+								Reference: runtimev1alpha1.TypedReference{
+									APIVersion: "apiVersion1",
+									Kind:       "kind1",
+									Name:       "trait1",
+								},
+							},
+						},
+					},
+				},
+			},
+			acPatchStatus: v1alpha2.ApplicationConfigurationStatus{
+				Workloads: []v1alpha2.WorkloadStatus{
+					{
+						Status:                "we need to add this",
+						ComponentRevisionName: "test-v2",
+						Traits: []v1alpha2.WorkloadTrait{
+							{
+								Status: "add this too",
+								Reference: runtimev1alpha1.TypedReference{
+									APIVersion: "apiVersion1",
+									Kind:       "kind1",
+									Name:       "trait1",
+								},
+							},
+						},
+					},
+				},
+			},
+			wantedStatus: &v1alpha2.ApplicationConfigurationStatus{
+				Workloads: []v1alpha2.WorkloadStatus{
+					{
+						HistoryWorkingRevision: false,
+						ComponentName:          "test",
+						ComponentRevisionName:  "test-v1",
+						Traits: []v1alpha2.WorkloadTrait{
+							{
+								Reference: runtimev1alpha1.TypedReference{
+									APIVersion: "apiVersion1",
+									Kind:       "kind1",
+									Name:       "trait1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			patchExtraStatusField(tt.acStatus, tt.acPatchStatus)
+			if diff := cmp.Diff(tt.acStatus, tt.wantedStatus); diff != "" {
+				t.Errorf("didn't patch to the statsu correctly: %s", diff)
+			}
+
+		})
+	}
+}

--- a/test/e2e-test/health_scope_test.go
+++ b/test/e2e-test/health_scope_test.go
@@ -64,7 +64,7 @@ var _ = Describe("HealthScope", func() {
 		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))).Should(BeNil())
 	})
 
-	It("apply an application config", func() {
+	It("Test an application config with health scope", func() {
 		healthScopeName := "example-health-scope"
 		// create health scope definition
 		sd := v1alpha2.ScopeDefinition{


### PR DESCRIPTION
The status fields in the workload disappear after a reconcile loop.  The culprit is that the controller runtime merge function doesn't know how to patch a simple Json object... The solution is to manually patch it on the clientside (lame)