### PR TITLE
Run with fewer privileges

### DIFF
--- a/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
+++ b/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
@@ -5,18 +5,60 @@ kind: ServiceAccount
 metadata:
   name: {{ include "oam-kubernetes-runtime.serviceAccountName" . }}
   labels:
-  {{ include "oam-kubernetes-runtime.labels" . | nindent 4 }}
-  {{- end }}
----
+  {{- include "oam-kubernetes-runtime.labels" . | nindent 4 }}
+{{- end }}
 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "oam-kubernetes-runtime.fullname" . }}
+  labels:
+  {{- include "oam-kubernetes-runtime.labels" . | nindent 4 }}
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.oam.dev/aggregate-to-controller: "true"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "oam-kubernetes-runtime.fullname" . }}:system:aggregate-to-controller
+  labels:
+    {{- include "oam-kubernetes-runtime.labels" . | nindent 4 }}
+    rbac.oam.dev/aggregate-to-controller: "true"
+rules:
+- apiGroups:
+  - core.oam.dev
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployment
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - service
+  verbs:
+  - "*"
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: manager-rolebinding
+  name: {{ include "oam-kubernetes-runtime.fullname" . }}
+  labels:
+  {{- include "oam-kubernetes-runtime.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: "cluster-admin"
+  name: {{ include "oam-kubernetes-runtime.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "oam-kubernetes-runtime.serviceAccountName" . }}
@@ -27,7 +69,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: leader-election-role
+  name: {{ include "oam-kubernetes-runtime.fullname" . }}-leader-election
+  labels:
+  {{- include "oam-kubernetes-runtime.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -60,11 +104,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: {{ include "oam-kubernetes-runtime.fullname" . }}-leader-election
+  labels:
+  {{- include "oam-kubernetes-runtime.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: leader-election-role
+  name: {{ include "oam-kubernetes-runtime.fullname" . }}-leader-election
 subjects:
   - kind: ServiceAccount
     name: {{ include "oam-kubernetes-runtime.serviceAccountName" . }}

--- a/test/e2e-test/suite_test.go
+++ b/test/e2e-test/suite_test.go
@@ -170,6 +170,10 @@ var _ = BeforeSuite(func(done Done) {
 				Kind: "User",
 				Name: "system:serviceaccount:crossplane-system:crossplane",
 			},
+			{
+				Kind: "User",
+				Name: "system:serviceaccount:oam-system:oam-kubernetes-runtime-e2e",
+			},
 		},
 		RoleRef: rbac.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",

--- a/test/e2e-test/suite_test.go
+++ b/test/e2e-test/suite_test.go
@@ -49,6 +49,7 @@ var k8sClient client.Client
 var scheme = runtime.NewScheme()
 var manualscalertrait v1alpha2.TraitDefinition
 var extendedmanualscalertrait v1alpha2.TraitDefinition
+var roleName = "oam-example-com"
 var roleBindingName = "oam-role-binding"
 var crd crdv1.CustomResourceDefinition
 
@@ -160,16 +161,29 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(k8sClient.Create(context.Background(), &wd)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
 	By("Created containerizedworkload.core.oam.dev")
 
+	exampleClusterRole := rbac.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: roleName,
+			Labels: map[string]string{
+				"oam":                                  "clusterrole",
+				"rbac.oam.dev/aggregate-to-controller": "true",
+			},
+		},
+		Rules: []rbac.PolicyRule{{
+			APIGroups: []string{"example.com"},
+			Resources: []string{rbac.ResourceAll},
+			Verbs:     []string{rbac.VerbAll},
+		}},
+	}
+	Expect(k8sClient.Create(context.Background(), &exampleClusterRole)).Should(BeNil())
+	By("Created example.com cluster role for the test service account")
+
 	adminRoleBinding := rbac.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   roleBindingName,
 			Labels: map[string]string{"oam": "clusterrole"},
 		},
 		Subjects: []rbac.Subject{
-			{
-				Kind: "User",
-				Name: "system:serviceaccount:crossplane-system:crossplane",
-			},
 			{
 				Kind: "User",
 				Name: "system:serviceaccount:oam-system:oam-kubernetes-runtime-e2e",
@@ -182,7 +196,7 @@ var _ = BeforeSuite(func(done Done) {
 		},
 	}
 	Expect(k8sClient.Create(context.Background(), &adminRoleBinding)).Should(BeNil())
-	By("Created cluster role bind for the test service account")
+	By("Created cluster role binding for the test service account")
 	// Create a crd for appconfig dependency test
 	crd = crdv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes https://github.com/crossplane/oam-kubernetes-runtime/issues/218

This commit updates the Helm chart to avoid running as cluster-admin. Instead, the controller runs only with the privileges it needs 'out of the box'; i.e. to manage all core OAM types, as well as deployments and services.

The commit also includes a few small chart hygiene fixes; i.e. ensuring that names will not collide when multiple releases exist in the same cluster, and that all resources include the standard labels.