### PR TITLE
Update apply.go

### DIFF
--- a/pkg/controller/v1alpha2/applicationconfiguration/apply.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/apply.go
@@ -222,8 +222,10 @@ func (a *workloads) applyScope(ctx context.Context, wl Workload, s unstructured.
 				return nil
 			}
 		}
-	} else {
-		return errors.Wrapf(err, errFmtGetScopeWorkloadRef, s.GetAPIVersion(), s.GetKind(), s.GetName(), workloadRefsPath)
+	}else if err.Error() == "spec: no such field"{
+            // init scope, so not found field: spec
+	}else {
+	    return errors.Wrapf(err, errFmtGetScopeWorkloadRef, s.GetAPIVersion(), s.GetKind(), s.GetName(), workloadRefsPath)
 	}
 
 	refs = append(refs, workloadRef)


### PR DESCRIPTION
如果自定义的scope 对象 第一次创建的时候， 没有加入spec字段， 会报错，此时不应该return， 而应该继续向下执行， 第一次patch 成功后， 这一段 pave 就不会报错，然后检查workload ref 是否重复。