### PR TITLE
RBAC rules must use plural resource names

### DIFF
--- a/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
+++ b/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
@@ -38,13 +38,13 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployment
+  - deployments
   verbs:
   - "*"
 - apiGroups:
   - ""
   resources:
-  - service
+  - services
   verbs:
   - "*"
 


### PR DESCRIPTION
I was end-to-end testing our Crossplane documentation prior to the release tomorrow, and noticed that the OAM pod was complaining that it didn't have access to deployments. When I change these to plurals, the pods stop complaining.