### PR TITLE
Allow the OAM controller to create events

### DIFF
--- a/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
+++ b/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
@@ -44,6 +44,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
   - services
   verbs:
   - "*"


### PR DESCRIPTION
Not being able to create events doesn't break anything, but does hamper debugging, and creates log noise.

I've now tested our OAM docs with Crossplane end-to-end, so hopefully this is the last of the RBAC rules I missed in my original PR. :( 