### PR TITLE
Allow the OAM controller to create events

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,13 @@ name: Go
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - release-*
   pull_request:
-    branches: [master]
+    branches:
+      - master
+      - release-*
 
 jobs:
   build:

--- a/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
+++ b/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
@@ -44,6 +44,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
   - services
   verbs:
   - "*"


### PR DESCRIPTION
Not being able to create events doesn't break anything, but does hamper debugging, and creates log noise.
