### PR TITLE
healthscope support PodSpecWorkload

### DIFF
--- a/pkg/controller/v1alpha2/core/scopes/healthscope/healthscope_controller.go
+++ b/pkg/controller/v1alpha2/core/scopes/healthscope/healthscope_controller.go
@@ -38,8 +38,7 @@ import (
 
 const (
 	reconcileTimeout = 1 * time.Minute
-	// shortWait        = 30 * time.Second
-	longWait = 1 * time.Minute
+	longWait         = 1 * time.Minute
 )
 
 // Reconcile error strings.
@@ -123,7 +122,7 @@ func NewReconciler(m ctrl.Manager, o ...ReconcilerOption) *Reconciler {
 		record:       event.NewNopRecorder(),
 		traitChecker: WorkloadHealthCheckFn(CheckByHealthCheckTrait),
 		checkers: []WorloadHealthChecker{
-			WorkloadHealthCheckFn(CheckStandardContainerziedHealth),
+			WorkloadHealthCheckFn(CheckPodSpecWorkloadHealth),
 			WorkloadHealthCheckFn(CheckContainerziedWorkloadHealth),
 			WorkloadHealthCheckFn(CheckDeploymentHealth),
 			WorkloadHealthCheckFn(CheckStatefulsetHealth),

--- a/pkg/controller/v1alpha2/core/scopes/healthscope/standard_test.go
+++ b/pkg/controller/v1alpha2/core/scopes/healthscope/standard_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam/util"
 )
 
-func TestCheckStandardContainerziedHealth(t *testing.T) {
+func TestCheckPodSpecWorkloadHealth(t *testing.T) {
 	mockClient := test.NewMockClient()
 	scRef := runtimev1alpha1.TypedReference{}
-	scRef.SetGroupVersionKind(standardContainerziedGVK)
+	scRef.SetGroupVersionKind(podSpecWorkloadGVK)
 
 	deployRef := runtimev1alpha1.TypedReference{}
 	deployRef.SetGroupVersionKind(apps.SchemeGroupVersion.WithKind(kindDeployment))
@@ -29,7 +29,7 @@ func TestCheckStandardContainerziedHealth(t *testing.T) {
 	svcRefData, _ := util.Object2Map(svcRef)
 
 	scUnstructured := unstructured.Unstructured{}
-	scUnstructured.SetGroupVersionKind(standardContainerziedGVK)
+	scUnstructured.SetGroupVersionKind(podSpecWorkloadGVK)
 	unstructured.SetNestedSlice(scUnstructured.Object, []interface{}{deployRefData, svcRefData}, "status", "resources")
 
 	tests := []struct {
@@ -92,7 +92,7 @@ func TestCheckStandardContainerziedHealth(t *testing.T) {
 			},
 		},
 		{
-			caseName: "unhealthy for ContainerizedWorkload not found",
+			caseName: "unhealthy for PodSpecWorkload not found",
 			wlRef:    scRef,
 			mockGetFn: func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
 				return errMockErr
@@ -123,7 +123,7 @@ func TestCheckStandardContainerziedHealth(t *testing.T) {
 	for _, tc := range tests {
 		func(t *testing.T) {
 			mockClient.MockGet = tc.mockGetFn
-			result := CheckStandardContainerziedHealth(ctx, mockClient, tc.wlRef, namespace)
+			result := CheckPodSpecWorkloadHealth(ctx, mockClient, tc.wlRef, namespace)
 			if tc.expect == nil {
 				assert.Nil(t, result, tc.caseName)
 			} else {


### PR DESCRIPTION
Fix HealthScope to catch up with renaming StandardContainerized ==> PodSpecWorkload in oam-dev/kubevela.

Signed-off-by: roy wang <seiwy2010@gmail.com>