### PR TITLE
Run gh actions on release branches also

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,9 +2,13 @@ name: Go
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - release-*
   pull_request:
-    branches: [master]
+    branches:
+      - master
+      - release-*
 
 jobs:
   build:


### PR DESCRIPTION
Updates the build workflow to run on releases branches in addition to
master.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

@wonderflow I will cherry pick this in https://github.com/crossplane/oam-kubernetes-runtime/pull/241 to fix our blocker there as well.