### PR TITLE
minor tweak, assign the workloadRef during render instead of apply

### DIFF
--- a/pkg/controller/v1alpha2/applicationconfiguration/apply.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/apply.go
@@ -88,35 +88,20 @@ func (a *workloads) Apply(ctx context.Context, status []v1alpha2.WorkloadStatus,
 				return errors.Wrapf(err, errFmtApplyWorkload, wl.Workload.GetName())
 			}
 		}
-
+		for _, trait := range wl.Traits {
+			if trait.HasDep {
+				continue
+			}
+			t := trait.Object
+			if err := a.client.Apply(ctx, &trait.Object, ao...); err != nil {
+				return errors.Wrapf(err, errFmtApplyTrait, t.GetAPIVersion(), t.GetKind(), t.GetName())
+			}
+		}
 		workloadRef := runtimev1alpha1.TypedReference{
 			APIVersion: wl.Workload.GetAPIVersion(),
 			Kind:       wl.Workload.GetKind(),
 			Name:       wl.Workload.GetName(),
 		}
-
-		for _, trait := range wl.Traits {
-			if trait.HasDep {
-				continue
-			}
-			//  We only patch a TypedReference object to the trait if it asks for it
-			t := trait.Object
-			if traitDefinition, err := util.FetchTraitDefinition(ctx, a.rawClient, &trait.Object); err == nil {
-				workloadRefPath := traitDefinition.Spec.WorkloadRefPath
-				if len(workloadRefPath) != 0 {
-					if err := fieldpath.Pave(t.UnstructuredContent()).SetValue(workloadRefPath, workloadRef); err != nil {
-						return errors.Wrapf(err, errFmtSetWorkloadRef, t.GetName(), wl.Workload.GetName())
-					}
-				}
-			} else {
-				return errors.Wrapf(err, errFmtGetTraitDefinition, t.GetAPIVersion(), t.GetKind(), t.GetName())
-			}
-
-			if err := a.client.Apply(ctx, &trait.Object, ao...); err != nil {
-				return errors.Wrapf(err, errFmtApplyTrait, t.GetAPIVersion(), t.GetKind(), t.GetName())
-			}
-		}
-
 		for _, s := range wl.Scopes {
 			if err := a.applyScope(ctx, wl, s, workloadRef); err != nil {
 				return err

--- a/pkg/controller/v1alpha2/applicationconfiguration/render.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/render.go
@@ -179,7 +179,6 @@ func (r *components) renderComponent(ctx context.Context, acc v1alpha2.Applicati
 		trait := traits[i]
 		workloadRefPath := traitDef.Spec.WorkloadRefPath
 		if len(workloadRefPath) != 0 {
-			fmt.Printf("\n\n\nworkloadRef path = %s\n\n\n", workloadRefPath)
 			if err := fieldpath.Pave(trait.Object.UnstructuredContent()).SetValue(workloadRefPath, workloadRef); err != nil {
 				return nil, errors.Wrapf(err, errFmtSetWorkloadRef, trait.Object.GetName(), w.GetName())
 			}

--- a/pkg/controller/v1alpha2/applicationconfiguration/render.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/render.go
@@ -79,6 +79,8 @@ func (fn ComponentRenderFn) Render(ctx context.Context, ac *v1alpha2.Application
 	return fn(ctx, ac)
 }
 
+var _ ComponentRenderer = &components{}
+
 type components struct {
 	client   client.Reader
 	params   ParameterResolver
@@ -149,12 +151,14 @@ func (r *components) renderComponent(ctx context.Context, acc v1alpha2.Applicati
 	traits := make([]*Trait, 0, len(acc.Traits))
 	traitDefs := make([]v1alpha2.TraitDefinition, 0, len(acc.Traits))
 	compInfoLabels[oam.LabelOAMResourceType] = oam.ResourceTypeTrait
+
 	for _, ct := range acc.Traits {
 		t, traitDef, err := r.renderTrait(ctx, ct, ac, acc.ComponentName, ref, dag)
 		if err != nil {
 			return nil, err
 		}
 		util.AddLabels(t, compInfoLabels)
+
 		// pass through labels and annotation from app-config to trait
 		util.PassLabelAndAnnotation(ac, t)
 		traits = append(traits, &Trait{Object: *t})
@@ -163,7 +167,24 @@ func (r *components) renderComponent(ctx context.Context, acc v1alpha2.Applicati
 	if err := SetWorkloadInstanceName(traitDefs, w, c); err != nil {
 		return nil, err
 	}
-
+	// create the ref after the workload name is set
+	workloadRef := runtimev1alpha1.TypedReference{
+		APIVersion: w.GetAPIVersion(),
+		Kind:       w.GetKind(),
+		Name:       w.GetName(),
+	}
+	//  We only patch a TypedReference object to the trait if it asks for it
+	for i := range acc.Traits {
+		traitDef := traitDefs[i]
+		trait := traits[i]
+		workloadRefPath := traitDef.Spec.WorkloadRefPath
+		if len(workloadRefPath) != 0 {
+			fmt.Printf("\n\n\nworkloadRef path = %s\n\n\n", workloadRefPath)
+			if err := fieldpath.Pave(trait.Object.UnstructuredContent()).SetValue(workloadRefPath, workloadRef); err != nil {
+				return nil, errors.Wrapf(err, errFmtSetWorkloadRef, trait.Object.GetName(), w.GetName())
+			}
+		}
+	}
 	scopes := make([]unstructured.Unstructured, 0, len(acc.Scopes))
 	for _, cs := range acc.Scopes {
 		scopeObject, err := r.renderScope(ctx, cs, ac.GetNamespace())


### PR DESCRIPTION
Assign the workloadRef during render instead of apply phase. The result is a more clean-cut division between apply and render and one search for the traitDefinition instead of two. 