### PR TITLE
status.historyWorkloads should not be required in AC

### DIFF
--- a/apis/core/v1alpha2/core_types.go
+++ b/apis/core/v1alpha2/core_types.go
@@ -422,7 +422,7 @@ type ApplicationConfigurationStatus struct {
 	ObservedGeneration int64 `json:"observedGeneration"`
 
 	// HistoryWorkloads will record history but still working revision workloads.
-	HistoryWorkloads []HistoryWorkload `json:"historyWorkloads"`
+	HistoryWorkloads []HistoryWorkload `json:"historyWorkloads,omitempty"`
 }
 
 // DependencyStatus represents the observed state of the dependency of

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_applicationconfigurations.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_applicationconfigurations.yaml
@@ -547,8 +547,6 @@ spec:
                       type: object
                   type: object
                 type: array
-            required:
-            - historyWorkloads
             type: object
         type: object
     served: true


### PR DESCRIPTION
This PR fixes below case:

When error return, we don't set status of AC, then it complains:

```
2020-10-15T16:20:26.562+0800	ERROR	controller-runtime.controller	Reconciler error	{"controller": "oam/applicationconfiguration.core.oam.dev", "request": "default/myapp", "error": "cannot update application configuration status: ApplicationConfiguration.core.oam.dev \"myapp\" is invalid: status.historyWorkloads: Invalid value: \"null\": status.historyWorkloads in body must be of type array: \"null\"", "errorVerbose": "ApplicationConfiguration.core.oam.dev \"myapp\" is invalid: status.historyWorkloads: Invalid value: \"null\": status.historyWorkloads in body must be of type array: \"null\"\ncannot update application configuration status\ngithub.com/crossplane/oam-kubernetes-runtime/pkg/controller/v1alpha2/applicationconfiguration.(*OAMApplicationReconciler).Reconcile.func1\n\t/Users/sunjianbo/gopath/pkg/mod/github.com/crossplane/oam-kubernetes-runtime@v0.3.0-rc1/pkg/controller/v1alpha2/applicationconfiguration/applicationconfiguration.go:244\ngithub.com/crossplane/oam-kubernetes-runtime/pkg/controller/v1alpha2/applicationconfiguration.(*OAMApplicationReconciler).Reconcile\n\t/Users/sunjianbo/gopath/pkg/mod/github.com/crossplane/oam-kubernetes-runtime@v0.3.0-rc1/pkg/controller/v1alpha2/applicationconfiguration/applicationconfiguration.go:275\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/Users/sunjianbo/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:256\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/sunjianbo/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:232\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker\n\t/Users/sunjianbo/gopath/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:211\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/Users/sunjianbo/gopath/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/Users/sunjianbo/gopath/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/Users/sunjianbo/gopath/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.Until\n\t/Users/sunjianbo/gopath/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90\nruntime.goexit\n\t/usr/local/Cellar/go/1.14.2_1/libexec/src/runtime/asm_amd64.s:1373"}
```