### PR TITLE
Revert "Don't run CI on no-op changes"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,23 +29,9 @@ env:
   AWS_USR: ${{ secrets.AWS_USR }}
 
 jobs:
-  detect-noop:
-    runs-on: ubuntu-18.04
-    outputs:
-      noop: ${{ steps.noop.outputs.should_skip }}
-    steps:
-      - name: Detect No-op Changes
-        id: noop
-        uses: fkirc/skip-duplicate-actions@v2.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          paths_ignore: '["**.md", "**.png", "**.jpg"]'
-          do_not_skip: '["workflow_dispatch", "schedule", "push"]'
 
   lint:
     runs-on: ubuntu-18.04
-    needs: detect-noop
-    if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
       - name: Checkout
@@ -74,8 +60,6 @@ jobs:
 
   check-diff:
     runs-on: ubuntu-18.04
-    needs: detect-noop
-    if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
       - name: Checkout
@@ -103,8 +87,6 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-18.04
-    needs: detect-noop
-    if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
       - name: Checkout
@@ -141,8 +123,6 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-18.04
-    needs: detect-noop
-    if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
       - name: Setup QEMU
@@ -202,8 +182,6 @@ jobs:
 
   publish-artifacts:
     runs-on: ubuntu-18.04
-    needs: detect-noop
-    if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
       - name: Setup QEMU

--- a/test/e2e-test/component_version_test.go
+++ b/test/e2e-test/component_version_test.go
@@ -346,7 +346,7 @@ var _ = Describe("Versioning mechanism of components", func() {
 					w1.SetKind("Bar")
 					return k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: revisionNameV1}, &w1)
 				},
-				time.Second*15, time.Millisecond*500).Should(BeNil())
+				time.Second*60, time.Millisecond*500).Should(BeNil())
 			k1, _, _ := unstructured.NestedString(w1.Object, "spec", "key")
 			Expect(k1).Should(BeEquivalentTo("v1"), fmt.Sprintf("%v", w1.Object))
 


### PR DESCRIPTION
This reverts commit c74331059d1cabfd91effe48d7678b61b829789f.

The no-op check will make the CI pass even it's failed last time.

see https://github.com/crossplane/oam-kubernetes-runtime/pull/261