### PR TITLE
fix panic for missing latestRevision while render component

### DIFF
--- a/pkg/controller/v1alpha2/applicationconfiguration/render.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/render.go
@@ -56,6 +56,7 @@ const (
 	errFmtSetParam         = "cannot set parameter %q"
 	errFmtUnsupportedParam = "unsupported parameter %q"
 	errFmtRequiredParam    = "required parameter %q not specified"
+	errFmtCompRevision     = "cannot get latest revision for component %q while revision is enabled"
 	errSetValueForField    = "can not set value %q for fieldPath %q"
 )
 
@@ -257,6 +258,9 @@ func SetWorkloadInstanceName(traitDefs []v1alpha2.TraitDefinition, w *unstructur
 	}
 	pv := fieldpath.Pave(w.UnstructuredContent())
 	if isRevisionEnabled(traitDefs) {
+		if c.Status.LatestRevision == nil {
+			return fmt.Errorf(errFmtCompRevision, c.Name)
+		}
 		// if revisionEnabled, use revisionName as the workload name
 		if err := pv.SetString(instanceNamePath, c.Status.LatestRevision.Name); err != nil {
 			return errors.Wrapf(err, errSetValueForField, instanceNamePath, c.Status.LatestRevision)


### PR DESCRIPTION
It's possible to raise a panic while render revision-enabled Component.
The problem is found in [e2e-test for component-versioning](https://github.com/crossplane/oam-kubernetes-runtime/blob/4ea4b295981d929b7a5b3285aab770333fb943c6/test/e2e-test/component_version_test.go#L307). 

Signed-off-by: roy wang <seiwy2010@gmail.com>