### PR TITLE
fix unstable unit tests of AppConfig controller

### DIFF
--- a/pkg/controller/v1alpha2/applicationconfiguration/suite_test.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/suite_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	crdv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +38,7 @@ var reconciler *OAMApplicationReconciler
 var mgrclose chan struct{}
 var testEnv *envtest.Environment
 var cfg *rest.Config
-var k8sClient client.Client
+var k8sClient resource.ClientApplicator
 var scheme = runtime.NewScheme()
 var crd crdv1.CustomResourceDefinition
 
@@ -77,7 +78,15 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(depSchemeBuilder.AddToScheme(scheme)).Should(BeNil())
 
 	By("Setting up kubernetes client")
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		logf.Log.Error(err, "failed to create a client")
+		Fail("setup failed")
+	}
+	k8sClient = resource.ClientApplicator{
+		Client:     c,
+		Applicator: resource.NewAPIUpdatingApplicator(c),
+	}
 	if err != nil {
 		logf.Log.Error(err, "failed to create k8sClient")
 		Fail("setup failed")


### PR DESCRIPTION
In unit test, after applying Creat/Update/Apply of AppConfig or other related resources, it's necessary to check whether applying is successful before triggering the reconciliation of AppConfig. Otherwise, it's possible to fail the reconciliation for the inconsistent resources.

Signed-off-by: roy wang <seiwy2010@gmail.com>