### PR TITLE
Refine health diagnosis output 

### DIFF
--- a/pkg/controller/v1alpha2/applicationconfiguration/suite_test.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/suite_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	controllerscheme "sigs.k8s.io/controller-runtime/pkg/scheme"
 
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core"
@@ -199,3 +200,10 @@ var _ = AfterSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	close(mgrclose)
 })
+
+func reconcileRetry(r reconcile.Reconciler, req reconcile.Request) {
+	Eventually(func() error {
+		_, err := r.Reconcile(req)
+		return err
+	}, 3*time.Second, time.Second).Should(BeNil())
+}

--- a/pkg/controller/v1alpha2/core/scopes/healthscope/healthscope.go
+++ b/pkg/controller/v1alpha2/core/scopes/healthscope/healthscope.go
@@ -420,8 +420,8 @@ func (p PeerHealthConditions) MergePeerWorkloadsConditions(basic *WorkloadHealth
 	} else {
 		basic.Diagnosis = fmt.Sprintf("%s:%s", peerHCs[0].TargetWorkload.Name, peerHCs[0].Diagnosis)
 		for i, peerHC := range peerHCs[1:] {
-			if i > 1 && peerHC.Diagnosis == fmt.Sprintf(infoFmtReady, 0, 0) {
-				// skip timeworn ones requiring zero replica
+			if i > 0 && peerHC.Diagnosis == fmt.Sprintf(infoFmtReady, 0, 0) {
+				// skip timeworn ones
 				continue
 			}
 			basic.Diagnosis = fmt.Sprintf("%s %s:%s",

--- a/pkg/controller/v1alpha2/core/scopes/healthscope/healthscope_controller.go
+++ b/pkg/controller/v1alpha2/core/scopes/healthscope/healthscope_controller.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	reconcileTimeout = 1 * time.Minute
-	longWait         = 1 * time.Minute
+	longWait         = 10 * time.Second
 )
 
 // Reconcile error strings.


### PR DESCRIPTION
- Refine the output of HealthScope when target workload has peer versioning workloads.
The diagnosis will sort by the revision number in descending order.
And if the revision order is larger than 3 and its required replicas is 0,  don't show its diagnosis info.
```yaml
status:
  healthConditions:
  - componentName: example-component
    diagnosis: 'example-component-v6:Ready:1/1  example-component-v5:Ready:1/1  example-component-v4:Ready:0/0 '
    healthStatus: HEALTHY
    targetWorkload:
      apiVersion: core.oam.dev/v1alpha2
      kind: ContainerizedWorkload
      name: example-component-v6
      uid: 4242f59b-0cb9-4cd9-8641-fd128d59cd5a
```
- change HealthScope work interval from 1min => 10sec
- fix unstable unit test