### PR TITLE
add ApplyOnceOnly switch for production running requirement

### DIFF
--- a/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
+++ b/charts/oam-kubernetes-runtime/templates/oam-controller.yaml
@@ -151,6 +151,7 @@ spec:
           args:
             - "--metrics-addr=:8080"
             - "--enable-leader-election"
+            - "--apply-once-only={{ .Values.applyOnceOnly }}"
             {{ if .Values.useWebhook }}
             - "--use-webhook=true"
             - "--webhook-port={{ .Values.webhookService.port }}"

--- a/charts/oam-kubernetes-runtime/values.yaml.tmpl
+++ b/charts/oam-kubernetes-runtime/values.yaml.tmpl
@@ -4,6 +4,7 @@
 
 replicaCount: 1
 useWebhook: false
+applyOnceOnly: false
 image:
   repository: crossplane/oam-kubernetes-runtime
   tag: %%VERSION%%

--- a/cmd/oam-kubernetes-runtime/main.go
+++ b/cmd/oam-kubernetes-runtime/main.go
@@ -52,6 +52,8 @@ func main() {
 	flag.BoolVar(&logCompress, "log-compress", true, "Enable compression on the rotated logs.")
 	flag.IntVar(&controllerArgs.RevisionLimit, "revision-limit", 50,
 		"RevisionLimit is the maximum number of revisions that will be maintained. The default value is 50.")
+	flag.BoolVar(&controllerArgs.ApplyOnceOnly, "apply-once-only", false,
+		"For the purpose of some production environment that workload or trait should not be affected if no spec change")
 	flag.Parse()
 
 	// setup logging
@@ -100,6 +102,9 @@ func main() {
 		os.Exit(1)
 	}
 	oamLog.Info("starting the controller manager")
+	if controllerArgs.ApplyOnceOnly {
+		oamLog.Info("applyOnceOnly is enabled that means workload or trait only apply once if no spec change even they are changed by others")
+	}
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		oamLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,4 +18,8 @@ type Args struct {
 	// RevisionLimit is the maximum number of revisions that will be maintained.
 	// The default value is 50.
 	RevisionLimit int
+
+	// ApplyOnceOnly indicates whether workloads and traits should be
+	// affected if no spec change is made in the ApplicationConfiguration.
+	ApplyOnceOnly bool
 }

--- a/pkg/controller/v1alpha2/applicationconfiguration/apply_once_only_test.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/apply_once_only_test.go
@@ -1,0 +1,258 @@
+package applicationconfiguration
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam/util"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Test apply (workloads/traits) once only", func() {
+	const (
+		namespace       = "apply-once-only-test"
+		appName         = "example-app"
+		compName        = "example-comp"
+		traitName       = "example-trait"
+		image1          = "wordpress:latest"
+		image2          = "nginx:latest"
+		traitSpecValue1 = "test1"
+		traitSpecValue2 = "test2"
+	)
+	var (
+		ctx          = context.Background()
+		cw           v1alpha2.ContainerizedWorkload
+		component    v1alpha2.Component
+		fakeTrait    *unstructured.Unstructured
+		appConfig    v1alpha2.ApplicationConfiguration
+		appConfigKey = client.ObjectKey{
+			Name:      appName,
+			Namespace: namespace,
+		}
+		req = reconcile.Request{NamespacedName: appConfigKey}
+		ns  = corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+	)
+
+	BeforeEach(func() {
+		cw = v1alpha2.ContainerizedWorkload{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ContainerizedWorkload",
+				APIVersion: "core.oam.dev/v1alpha2",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+			},
+			Spec: v1alpha2.ContainerizedWorkloadSpec{
+				Containers: []v1alpha2.Container{
+					{
+						Name:  "wordpress",
+						Image: image1,
+						Ports: []v1alpha2.ContainerPort{
+							{
+								Name: "wordpress",
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+		}
+		component = v1alpha2.Component{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "core.oam.dev/v1alpha2",
+				Kind:       "Component",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      compName,
+				Namespace: namespace,
+			},
+			Spec: v1alpha2.ComponentSpec{
+				Workload: runtime.RawExtension{
+					Object: &cw,
+				},
+			},
+		}
+
+		fakeTrait = &unstructured.Unstructured{}
+		fakeTrait.SetAPIVersion("example.com/v1")
+		fakeTrait.SetKind("Foo")
+		fakeTrait.SetNamespace(namespace)
+		fakeTrait.SetName(traitName)
+		unstructured.SetNestedField(fakeTrait.Object, traitSpecValue1, "spec", "key")
+
+		appConfig = v1alpha2.ApplicationConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      appName,
+				Namespace: namespace,
+			},
+			Spec: v1alpha2.ApplicationConfigurationSpec{
+				Components: []v1alpha2.ApplicationConfigurationComponent{
+					{
+						ComponentName: compName,
+						Traits: []v1alpha2.ComponentTrait{
+							{Trait: runtime.RawExtension{Object: fakeTrait}},
+						},
+					},
+				},
+			},
+		}
+
+		logf.Log.Info("Start to run a test, clean up previous resources")
+		// delete the namespace with all its resources
+		Expect(k8sClient.Delete(ctx, &ns, client.PropagationPolicy(metav1.DeletePropagationForeground))).
+			Should(SatisfyAny(BeNil(), &util.NotFoundMatcher{}))
+		logf.Log.Info("make sure all the resources are removed")
+		Eventually(
+			// gomega has a bug that can't take nil as the actual input, so has to make it a func
+			func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: namespace}, &corev1.Namespace{})
+			},
+			time.Second*120, time.Millisecond*500).Should(&util.NotFoundMatcher{})
+
+		By("Create namespace")
+		Eventually(
+			func() error {
+				return k8sClient.Create(ctx, &ns)
+			},
+			time.Second*3, time.Millisecond*300).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
+		By("Create Component")
+		Expect(k8sClient.Create(ctx, &component)).Should(Succeed())
+		cmpV1 := &v1alpha2.Component{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: compName}, cmpV1)).Should(Succeed())
+
+		By("Creat appConfig & check successfully")
+		Expect(k8sClient.Create(ctx, &appConfig)).Should(Succeed())
+		Eventually(func() error {
+			return k8sClient.Get(ctx, appConfigKey, &appConfig)
+		}, time.Second, 300*time.Millisecond).Should(BeNil())
+
+		By("Enable ApplyOnceOnly")
+		reconciler.applyOnceOnly = true
+
+		By("Reconcile")
+		Expect(func() error { _, err := reconciler.Reconcile(req); return err }()).Should(BeNil())
+	})
+
+	AfterEach(func() {
+		// restore as default value
+		reconciler.applyOnceOnly = false
+	})
+
+	When("Change workload/trait instance bypass ApplicationConfiguration", func() {
+		It("should keep workload instanced not changed by reconciliation", func() {
+			By("Get workload instance & Check workload spec")
+			cwObj := v1alpha2.ContainerizedWorkload{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: compName, Namespace: namespace}, &cwObj)
+			}, 3*time.Second, time.Second).Should(BeNil())
+			Expect(cwObj.Spec.Containers[0].Image).Should(Equal(image1))
+
+			By("Get trait instance & Check trait spec")
+			fooObj := &unstructured.Unstructured{}
+			fooObj.SetAPIVersion("example.com/v1")
+			fooObj.SetKind("Foo")
+			Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKey{Name: traitName, Namespace: namespace}, fooObj)
+			}, 3*time.Second, time.Second).Should(BeNil())
+			fooObjV, _, _ := unstructured.NestedString(fooObj.Object, "spec", "key")
+			Expect(fooObjV).Should(Equal(traitSpecValue1))
+
+			By("Modify workload spec & Apply changed workload")
+			cwObj.Spec.Containers[0].Image = image2
+			Expect(k8sClient.Apply(ctx, &cwObj)).Should(Succeed())
+
+			By("Modify trait spec & Apply changed trait")
+			unstructured.SetNestedField(fooObj.Object, traitSpecValue2, "spec", "key")
+			Expect(k8sClient.Apply(ctx, fooObj)).Should(Succeed())
+
+			By("Get updated workload instance & Check workload spec")
+			updateCwObj := v1alpha2.ContainerizedWorkload{}
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: compName, Namespace: namespace}, &updateCwObj); err != nil {
+					return ""
+				}
+				return updateCwObj.Spec.Containers[0].Image
+			}, 3*time.Second, time.Second).Should(Equal(image2))
+
+			By("Get updated trait instance & Check trait spec")
+			updatedFooObj := &unstructured.Unstructured{}
+			updatedFooObj.SetAPIVersion("example.com/v1")
+			updatedFooObj.SetKind("Foo")
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: traitName, Namespace: namespace}, updatedFooObj); err != nil {
+					return ""
+				}
+				v, _, _ := unstructured.NestedString(fooObj.Object, "spec", "key")
+				return v
+			}, 3*time.Second, time.Second).Should(Equal(traitSpecValue2))
+
+			By("Reconcile")
+			Expect(func() error { _, err := reconciler.Reconcile(req); return err }()).Should(BeNil())
+			time.Sleep(3 * time.Second)
+
+			By("Check workload is not changed by reconciliation")
+			updateCwObj = v1alpha2.ContainerizedWorkload{}
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: compName, Namespace: namespace}, &updateCwObj); err != nil {
+					return ""
+				}
+				return updateCwObj.Spec.Containers[0].Image
+			}, 3*time.Second, time.Second).Should(Equal(image2))
+
+			By("Check trait is not changed by reconciliation")
+			updatedFooObj = &unstructured.Unstructured{}
+			updatedFooObj.SetAPIVersion("example.com/v1")
+			updatedFooObj.SetKind("Foo")
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: traitName, Namespace: namespace}, updatedFooObj); err != nil {
+					return ""
+				}
+				v, _, _ := unstructured.NestedString(updatedFooObj.Object, "spec", "key")
+				return v
+			}, 3*time.Second, time.Second).Should(Equal(traitSpecValue2))
+
+			By("Disable ApplyOnceOnly & Reconcile again")
+			reconciler.applyOnceOnly = false
+			Expect(func() error { _, err := reconciler.Reconcile(req); return err }()).Should(BeNil())
+
+			By("Check workload is changed by reconciliation")
+			updateCwObj = v1alpha2.ContainerizedWorkload{}
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: compName, Namespace: namespace}, &updateCwObj); err != nil {
+					return ""
+				}
+				return updateCwObj.Spec.Containers[0].Image
+			}, 3*time.Second, time.Second).Should(Equal(image1))
+
+			By("Check trait is changed by reconciliation")
+			updatedFooObj = &unstructured.Unstructured{}
+			updatedFooObj.SetAPIVersion("example.com/v1")
+			updatedFooObj.SetKind("Foo")
+			Eventually(func() string {
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: traitName, Namespace: namespace}, updatedFooObj); err != nil {
+					return ""
+				}
+				v, _, _ := unstructured.NestedString(updatedFooObj.Object, "spec", "key")
+				return v
+			}, 3*time.Second, time.Second).Should(Equal(traitSpecValue1))
+		})
+	})
+
+})

--- a/pkg/controller/v1alpha2/applicationconfiguration/dependency_test.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/dependency_test.go
@@ -484,10 +484,10 @@ var _ = Describe("Resource Dependency in an ApplicationConfiguration", func() {
 						"spec.key",
 					}}}},
 		}
-		Expect(func() v1alpha2.DependencyStatus {
+		Eventually(func() v1alpha2.DependencyStatus {
 			k8sClient.Get(ctx, appconfigKey, newAppConfig)
 			return newAppConfig.Status.Dependency
-		}()).Should(Equal(depStatus))
+		}, time.Second, 300*time.Millisecond).Should(Equal(depStatus))
 
 		By("Update trait resource to meet the requirement")
 		Expect(k8sClient.Get(ctx, outFooKey, outFoo)).Should(BeNil()) // Get the latest before update

--- a/pkg/controller/v1alpha2/applicationconfiguration/render.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/render.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
@@ -146,6 +147,11 @@ func (r *components) renderComponent(ctx context.Context, acc v1alpha2.Applicati
 	}
 	util.AddLabels(w, compInfoLabels)
 
+	compInfoAnnotations := map[string]string{
+		oam.AnnotationAppGeneration: strconv.Itoa(int(ac.Generation)),
+	}
+	util.AddAnnotations(w, compInfoAnnotations)
+
 	// pass through labels and annotation from app-config to workload
 	util.PassLabelAndAnnotation(ac, w)
 
@@ -163,6 +169,7 @@ func (r *components) renderComponent(ctx context.Context, acc v1alpha2.Applicati
 			return nil, err
 		}
 		util.AddLabels(t, compInfoLabels)
+		util.AddAnnotations(t, compInfoAnnotations)
 
 		// pass through labels and annotation from app-config to trait
 		util.PassLabelAndAnnotation(ac, t)

--- a/pkg/controller/v1alpha2/applicationconfiguration/render_test.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/render_test.go
@@ -230,6 +230,9 @@ func TestRenderComponents(t *testing.T) {
 							w.SetNamespace(namespace)
 							w.SetName(workloadName)
 							w.SetOwnerReferences([]metav1.OwnerReference{*ref})
+							w.SetAnnotations(map[string]string{
+								oam.AnnotationAppGeneration: "0",
+							})
 							w.SetLabels(map[string]string{
 								oam.LabelAppComponent:         componentName,
 								oam.LabelAppName:              acName,
@@ -244,6 +247,9 @@ func TestRenderComponents(t *testing.T) {
 								t.SetNamespace(namespace)
 								t.SetName(traitName)
 								t.SetOwnerReferences([]metav1.OwnerReference{*ref})
+								t.SetAnnotations(map[string]string{
+									oam.AnnotationAppGeneration: "0",
+								})
 								t.SetLabels(map[string]string{
 									oam.LabelAppComponent:         componentName,
 									oam.LabelAppName:              acName,
@@ -305,6 +311,9 @@ func TestRenderComponents(t *testing.T) {
 							w.SetNamespace(namespace)
 							w.SetName(componentName)
 							w.SetOwnerReferences([]metav1.OwnerReference{*ref})
+							w.SetAnnotations(map[string]string{
+								oam.AnnotationAppGeneration: "0",
+							})
 							w.SetLabels(map[string]string{
 								oam.LabelAppComponent:         componentName,
 								oam.LabelAppName:              acName,
@@ -319,6 +328,9 @@ func TestRenderComponents(t *testing.T) {
 								t.SetNamespace(namespace)
 								t.SetName(traitName)
 								t.SetOwnerReferences([]metav1.OwnerReference{*ref})
+								t.SetAnnotations(map[string]string{
+									oam.AnnotationAppGeneration: "0",
+								})
 								t.SetLabels(map[string]string{
 									oam.LabelAppComponent:         componentName,
 									oam.LabelAppName:              acName,
@@ -371,6 +383,9 @@ func TestRenderComponents(t *testing.T) {
 							w.SetNamespace(namespace)
 							w.SetName(revisionName2)
 							w.SetOwnerReferences([]metav1.OwnerReference{*ref})
+							w.SetAnnotations(map[string]string{
+								oam.AnnotationAppGeneration: "0",
+							})
 							w.SetLabels(map[string]string{
 								oam.LabelAppComponent:         componentName,
 								oam.LabelAppName:              acName,
@@ -385,6 +400,9 @@ func TestRenderComponents(t *testing.T) {
 								t.SetNamespace(namespace)
 								t.SetName(traitName)
 								t.SetOwnerReferences([]metav1.OwnerReference{*ref})
+								t.SetAnnotations(map[string]string{
+									oam.AnnotationAppGeneration: "0",
+								})
 								t.SetLabels(map[string]string{
 									oam.LabelAppComponent:         componentName,
 									oam.LabelAppName:              acName,
@@ -461,6 +479,9 @@ func TestRenderComponents(t *testing.T) {
 							w.SetNamespace(namespace)
 							w.SetName(componentName)
 							w.SetOwnerReferences([]metav1.OwnerReference{*ref})
+							w.SetAnnotations(map[string]string{
+								oam.AnnotationAppGeneration: "0",
+							})
 							w.SetLabels(map[string]string{
 								oam.LabelAppComponent:         componentName,
 								oam.LabelAppName:              acName,
@@ -475,6 +496,9 @@ func TestRenderComponents(t *testing.T) {
 								tr.SetNamespace(namespace)
 								tr.SetName(traitName)
 								tr.SetOwnerReferences([]metav1.OwnerReference{*ref})
+								tr.SetAnnotations(map[string]string{
+									oam.AnnotationAppGeneration: "0",
+								})
 								tr.SetLabels(map[string]string{
 									oam.LabelAppComponent:         componentName,
 									oam.LabelAppName:              acName,

--- a/pkg/oam/discoverymapper/suit_test.go
+++ b/pkg/oam/discoverymapper/suit_test.go
@@ -124,6 +124,14 @@ var _ = Describe("Mapper discovery resources", func() {
 			},
 		}
 		Expect(k8sClient.Create(context.Background(), &crd)).Should(BeNil())
+		updatedCrdObj := crdv1.CustomResourceDefinition{}
+		Eventually(func() bool {
+			if err := k8sClient.Get(context.Background(),
+				client.ObjectKey{Name: "foos.example.com"}, &updatedCrdObj); err != nil {
+				return false
+			}
+			return len(updatedCrdObj.Spec.Versions) == 2
+		}, 3*time.Second, time.Second).Should(BeTrue())
 
 		Eventually(func() error {
 			mapping, err = dism.RESTMapping(schema.GroupKind{Group: "example.com", Kind: "Foo"}, "v1")

--- a/pkg/oam/labels.go
+++ b/pkg/oam/labels.go
@@ -40,3 +40,8 @@ const (
 	// ResourceTypeWorkload mark this K8s Custom Resource is an OAM workload
 	ResourceTypeWorkload = "WORKLOAD"
 )
+
+const (
+	// AnnotationAppGeneration records the generation of AppConfig
+	AnnotationAppGeneration = "app.oam.dev/generation"
+)

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -434,6 +434,11 @@ func AddLabels(o *unstructured.Unstructured, labels map[string]string) {
 	o.SetLabels(MergeMapOverrideWithDst(o.GetLabels(), labels))
 }
 
+// AddAnnotations will merge annotations with existing ones. If any conflict keys, use new value to override existing value.
+func AddAnnotations(o *unstructured.Unstructured, annos map[string]string) {
+	o.SetAnnotations(MergeMapOverrideWithDst(o.GetAnnotations(), annos))
+}
+
 // MergeMapOverrideWithDst merges two could be nil maps. If any conflicts, override src with dst.
 func MergeMapOverrideWithDst(src, dst map[string]string) map[string]string {
 	if src == nil && dst == nil {


### PR DESCRIPTION
to fix #277 
Add a "ApplyOnceOnly(bool type)" switch for AppConfig controller.  By default it's false.
Once it's enabled, the reconciler will not affect underlying workload and trait CR if no generation changed.
As for Create & Delete events occurring on AppConfig and Component, it works as before.
But for Update events, reconciliation is triggered when the object's metadata.labels/annotations/finalizers, or spec is changed.


Signed-off-by: roy wang <seiwy2010@gmail.com>