### PR TITLE
Change default service type to ClusterIP

### DIFF
--- a/pkg/controller/v1alpha2/core/workloads/containerizedworkload/containerizedworkload_controller_helper.go
+++ b/pkg/controller/v1alpha2/core/workloads/containerizedworkload/containerizedworkload_controller_helper.go
@@ -63,7 +63,7 @@ func (r *Reconciler) renderService(ctx context.Context,
 	}
 	// the service injector lib doesn't set the namespace and serviceType
 	service.Namespace = workload.Namespace
-	service.Spec.Type = corev1.ServiceTypeNodePort
+	service.Spec.Type = corev1.ServiceTypeClusterIP
 	// k8s server-side patch complains if the protocol is not set
 	for i := 0; i < len(service.Spec.Ports); i++ {
 		service.Spec.Ports[i].Protocol = corev1.ProtocolTCP


### PR DESCRIPTION
NodePort might be useful for some demos (especially with minikube),
but it isn't a great default for all scenarios. ClusterIP is a
safer default, and you can always forward a port to it if you
don't have ingress.

As discussed on slack, here is a PR to change the default service
type. Eventually I guess this would be a trait, but for now I
just switch the default.