### PR TITLE
fix ci failed for error on fetching azure-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
 
       - name: Install ginkgo
         run:  |
+          sudo rm -rf /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update
           sudo apt-get install -y golang-ginkgo-dev
 


### PR DESCRIPTION
related to https://github.community/t/errors-on-updating-apt-cache-for-azure-cli/17316
Update in https://packages.microsoft.com/repos/azure-cli/dists/bionic/main/binary-amd64/ results in `sudo apt-get install -y golang-ginkgo-dev` failed in CI.

```shell
Fetched 8669 kB in 3s (3401 kB/s)
Reading package lists...
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/bionic/main/binary-amd64/Packages.bz2  File has unexpected size (11635 != 11530). Mirror sync in progress? [IP: 40.117.131.251 443]
   Hashes of expected file:
    - Filesize:11530 [weak]
    - SHA512:721e2fd23ead08d56783ffbd1ad57e8cee8b91391de7e96ecc0a13ecb030666503f6807d1d0ffcc7055ed1611d4a600617c12abadbc3c780c0418994ab49935a
    - SHA256:ae1bff8772d7a9e4007e78482d5a513a200a24c9627412091fe2ce328cc657c4
    - SHA1:51e1d9fb31e9e59b91054c0a97965466193d7219 [weak]
    - MD5Sum:db70dd3d7eb955f155e4970f9c6e4ce9 [weak]
   Release file created at: Mon, 09 Nov 2020 09:24:42 +0000
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

Signed-off-by: roy wang <seiwy2010@gmail.com>