### PR TITLE
update helm uninstall name

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ But be aware that in this case, you will lose critical validations and injection
 
 ## Cleanup
 ```console
-helm uninstall core-runtime -n oam-system
+helm uninstall oam -n oam-system
 kubectl delete -f examples/containerized-workload
 kubectl delete namespace oam-system --wait
 ```


### PR DESCRIPTION
 I can't uninstall helm object form document because helm name is oam and not core-runtime in the helm install document.

helm uninstall original content:
```
helm uninstall core-runtime -n oam-system
```

helm install content:
```
helm install oam --namespace oam-system crossplane-master/oam-kubernetes-runtime --devel
```