### PR TITLE
Apply CRDs of WorkloadDefinition and TraitDefinition during e2e setup …

### DIFF
--- a/test/e2e-test/suite_test.go
+++ b/test/e2e-test/suite_test.go
@@ -94,6 +94,15 @@ var _ = BeforeSuite(func(done Done) {
 	}
 	By("Finished setting up test environment")
 
+	By("Applying CRD of WorkloadDefinition and TraitDefinition")
+	var workloadDefinitionCRD crdv1.CustomResourceDefinition
+	Expect(readYaml("../../charts/oam-kubernetes-runtime/crds/core.oam.dev_workloaddefinitions.yaml", &workloadDefinitionCRD)).Should(BeNil())
+	Expect(k8sClient.Create(context.Background(), &workloadDefinitionCRD)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
+	var traitDefinitionCRD crdv1.CustomResourceDefinition
+	Expect(readYaml("../../charts/oam-kubernetes-runtime/crds/core.oam.dev_traitdefinitions.yaml", &traitDefinitionCRD)).Should(BeNil())
+	Expect(k8sClient.Create(context.Background(), &traitDefinitionCRD)).Should(SatisfyAny(BeNil(), &util.AlreadyExistMatcher{}))
+
 	// Create manual scaler trait definition
 	manualscalertrait = v1alpha2.TraitDefinition{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
…stage

During local development of e2e testcases, CRDs of WorkloadDefintion
and TraitDefinition in charts/oam-kubernetes-runtime/crds has to be
manually applied during each single run of suite_test. Though they are
applied in `make e2e-setup` stage, it won't help local development.

Fix #303

Signed-off-by: zzxwill <zzxwill@gmail.com>