### PR TITLE
Implement traits ConflictsWith

### DIFF
--- a/apis/core/v1alpha2/core_types.go
+++ b/apis/core/v1alpha2/core_types.go
@@ -114,6 +114,12 @@ type TraitDefinitionSpec struct {
 	// +optional
 	AppliesToWorkloads []string `json:"appliesToWorkloads,omitempty"`
 
+	// ConflictsWith specifies the list of traits which could not apply to the
+	// same workloads with this trait. Traits that omit this field can work with
+	// any other traits.
+	// +optional
+	ConflictsWith []string `json:"conflictsWith,omitempty"`
+
 	// Extension is used for extension needs by OAM platform builders
 	// +optional
 	// +kubebuilder:pruning:PreserveUnknownFields

--- a/apis/core/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/core/v1alpha2/zz_generated.deepcopy.go
@@ -1451,6 +1451,11 @@ func (in *TraitDefinitionSpec) DeepCopyInto(out *TraitDefinitionSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ConflictsWith != nil {
+		in, out := &in.ConflictsWith, &out.ConflictsWith
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Extension != nil {
 		in, out := &in.Extension, &out.Extension
 		*out = new(runtime.RawExtension)

--- a/charts/oam-kubernetes-runtime/crds/core.oam.dev_traitdefinitions.yaml
+++ b/charts/oam-kubernetes-runtime/crds/core.oam.dev_traitdefinitions.yaml
@@ -44,6 +44,11 @@ spec:
                 items:
                   type: string
                 type: array
+              conflictsWith:
+                description: ConflictsWith specifies the list of traits which could not apply to the same workloads with this trait. Traits that omit this field can work with any other traits.
+                items:
+                  type: string
+                type: array
               definitionRef:
                 description: Reference to the CustomResourceDefinition that defines this trait kind.
                 properties:

--- a/legacy/charts/oam-kubernetes-runtime-legacy/crds/core.oam.dev_traitdefinitions.yaml
+++ b/legacy/charts/oam-kubernetes-runtime-legacy/crds/core.oam.dev_traitdefinitions.yaml
@@ -43,6 +43,11 @@ spec:
               items:
                 type: string
               type: array
+            conflictsWith:
+              description: ConflictsWith specifies the list of traits which could not apply to the same workloads with this trait. Traits that omit this field can work with any other traits.
+              items:
+                type: string
+              type: array
             definitionRef:
               description: Reference to the CustomResourceDefinition that defines this trait kind.
               properties:

--- a/pkg/controller/v1alpha2/applicationconfiguration/applicationconfiguration.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/applicationconfiguration.go
@@ -179,7 +179,7 @@ func NewReconciler(m ctrl.Manager, dm discoverymapper.DiscoveryMapper, o ...Reco
 			dm:       dm,
 			params:   ParameterResolveFn(resolve),
 			workload: ResourceRenderFn(renderWorkload),
-			trait:    ResourceRenderFn(renderTrait),
+			trait:    ResourceRenderFn(RenderTrait),
 		},
 		workloads: &workloads{
 			// NOTE(roywang) PatchingApplicator@v0.10.0 only use "application/merge-patch+json" type patch

--- a/pkg/controller/v1alpha2/applicationconfiguration/apply.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/apply.go
@@ -45,6 +45,7 @@ const (
 	errFmtGetScopeWorkloadRefsPath = "cannot get workloadRefsPath for scope to be dereferenced %q %q %q"
 	errFmtApplyTrait               = "cannot apply trait %q %q %q"
 	errFmtApplyScope               = "cannot apply scope %q %q %q"
+	errFmtConflictsTrait           = "cannot apply trait %q %q %q whose conflictsWith is %q"
 
 	workloadScopeFinalizer = "scope.finalizer.core.oam.dev"
 )

--- a/pkg/controller/v1alpha2/applicationconfiguration/apply.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/apply.go
@@ -45,7 +45,6 @@ const (
 	errFmtGetScopeWorkloadRefsPath = "cannot get workloadRefsPath for scope to be dereferenced %q %q %q"
 	errFmtApplyTrait               = "cannot apply trait %q %q %q"
 	errFmtApplyScope               = "cannot apply scope %q %q %q"
-	errFmtConflictsTrait           = "cannot apply trait %q %q %q whose conflictsWith is %q"
 
 	workloadScopeFinalizer = "scope.finalizer.core.oam.dev"
 )

--- a/pkg/controller/v1alpha2/applicationconfiguration/render_test.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/render_test.go
@@ -645,7 +645,7 @@ func TestRenderTrait(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, err := renderTrait(tc.args.data)
+			got, err := RenderTrait(tc.args.data)
 			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
 				t.Errorf("\n%s\nrenderTrait(...): -want error, +got error:\n%s\n", tc.reason, diff)
 			}

--- a/pkg/oam/util/helper.go
+++ b/pkg/oam/util/helper.go
@@ -450,3 +450,13 @@ func MergeMapOverrideWithDst(src, dst map[string]string) map[string]string {
 	}
 	return r
 }
+
+// Contains whether a slice contains an item
+func Contains(slice []string, elem string) bool {
+	for _, s := range slice {
+		if s == elem {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/webhook/v1alpha2/applicationconfiguration/handler_test.go
+++ b/pkg/webhook/v1alpha2/applicationconfiguration/handler_test.go
@@ -251,7 +251,7 @@ var _ = Describe("ApplicationConfiguration Admission controller Test", func() {
 				reason:    "",
 				client:    clientInstance,
 			},
-			"malformat appConfig": {
+			"malformed appConfig": {
 				trait:     "bad format",
 				operation: admissionv1beta1.Create,
 				pass:      false,

--- a/test/e2e-test/traits_conflict_test.go
+++ b/test/e2e-test/traits_conflict_test.go
@@ -1,0 +1,184 @@
+package controllers_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
+	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam"
+)
+
+var _ = Describe("Trait conflict", func() {
+	ctx := context.Background()
+	apiVersion := "core.oam.dev/v1alpha2"
+	namespace := "default"
+	componentName := "conflict"
+	appConfigName := "conflict"
+	workload := v1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace},
+		Spec: v1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "nginx",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "nginx",
+							Image: "nginx:1.9.4"},
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "nginx"}},
+			},
+		},
+	}
+	component := v1alpha2.Component{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiVersion,
+			Kind:       "Component",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: componentName, Namespace: namespace},
+		Spec: v1alpha2.ComponentSpec{
+			Workload: runtime.RawExtension{Object: workload.DeepCopyObject()},
+		},
+	}
+
+	traitTypeMeta := metav1.TypeMeta{
+		APIVersion: apiVersion,
+		Kind:       "TraitDefinition",
+	}
+
+	var traitDefinition1Name = "trait1.core.oam.dev"
+	traitDefinition1 := v1alpha2.TraitDefinition{
+		TypeMeta: traitTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      traitDefinition1Name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha2.TraitDefinitionSpec{
+			Reference: v1alpha2.DefinitionReference{
+				Name: traitDefinition1Name,
+			},
+			WorkloadRefPath: "spec.workloadRef",
+		},
+	}
+
+	var traitDefinition2Name = "trait2.core.oam.dev"
+	traitDefinition2 := v1alpha2.TraitDefinition{
+		TypeMeta: traitTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      traitDefinition2Name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha2.TraitDefinitionSpec{
+			Reference: v1alpha2.DefinitionReference{
+				Name: traitDefinition2Name,
+			},
+			WorkloadRefPath: "spec.workloadRef",
+			ConflictsWith:   []string{traitDefinition1Name},
+		},
+	}
+
+	var traitDefinition3Name = "trait3.core.oam.dev"
+	traitDefinition3 := v1alpha2.TraitDefinition{
+		TypeMeta: traitTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      traitDefinition3Name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha2.TraitDefinitionSpec{
+			Reference: v1alpha2.DefinitionReference{
+				Name: traitDefinition3Name,
+			},
+			WorkloadRefPath: "spec.workloadRef",
+		},
+	}
+
+	var trait1, trait2, trait3 unstructured.Unstructured
+	trait1.SetAPIVersion(apiVersion)
+	trait1.SetKind("Trait1")
+	trait1.SetLabels(map[string]string{
+		oam.TraitTypeLabel: traitDefinition1Name,
+	})
+
+	trait2.SetAPIVersion(apiVersion)
+	trait2.SetKind("Trait2")
+	trait2.SetLabels(map[string]string{
+		oam.TraitTypeLabel: traitDefinition2Name,
+	})
+
+	trait3.SetAPIVersion(apiVersion)
+	trait3.SetKind("Trait3")
+	trait3.SetLabels(map[string]string{
+		oam.TraitTypeLabel: traitDefinition3Name,
+	})
+
+	appConfig := v1alpha2.ApplicationConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiVersion,
+			Kind:       "ApplicationConfiguration",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: appConfigName, Namespace: namespace},
+		Spec: v1alpha2.ApplicationConfigurationSpec{
+			Components: []v1alpha2.ApplicationConfigurationComponent{{
+				ComponentName: componentName,
+				Traits: []v1alpha2.ComponentTrait{
+					{Trait: runtime.RawExtension{Object: trait1.DeepCopyObject()}},
+					{Trait: runtime.RawExtension{Object: trait2.DeepCopyObject()}},
+					{Trait: runtime.RawExtension{Object: trait3.DeepCopyObject()}},
+				},
+			},
+			},
+		},
+	}
+
+	appConfigObjKey := client.ObjectKey{Name: appConfigName, Namespace: namespace}
+
+	BeforeEach(func() {
+		Expect(k8sClient.Create(ctx, &traitDefinition1)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, &traitDefinition2)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, &traitDefinition3)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, &component)).Should(Succeed())
+	})
+
+	Context("Apply conflicted traits", func() {
+		It("Apply conflicted traits when there is no existing traits", func() {
+			By("submit ApplicationConfiguration")
+			err := k8sClient.Create(ctx, &appConfig)
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("Apply a trait which conflicts to an existing traits", func() {
+			By("submit ApplicationConfiguration")
+			appConfig.Spec.Components[0].Traits = []v1alpha2.ComponentTrait{{Trait: runtime.RawExtension{Object: trait1.DeepCopyObject()}}}
+			Expect(k8sClient.Create(ctx, &appConfig)).Should(Succeed())
+
+			By("apply new ApplicationConfiguration with a conflicted trait")
+			Expect(k8sClient.Get(ctx, appConfigObjKey, &appConfig)).Should(Succeed())
+			appConfig.Spec.Components[0].Traits = []v1alpha2.ComponentTrait{
+				{Trait: runtime.RawExtension{Object: trait1.DeepCopyObject()}},
+				{Trait: runtime.RawExtension{Object: trait2.DeepCopyObject()}},
+				{Trait: runtime.RawExtension{Object: trait3.DeepCopyObject()}},
+			}
+			Expect(k8sClient.Update(ctx, &appConfig)).Should(HaveOccurred())
+		})
+	})
+
+	AfterEach(func() {
+		k8sClient.Delete(ctx, &appConfig)
+		k8sClient.Delete(ctx, &component)
+		k8sClient.Delete(ctx, &traitDefinition1)
+		k8sClient.Delete(ctx, &traitDefinition2)
+		k8sClient.Delete(ctx, &traitDefinition3)
+	})
+})


### PR DESCRIPTION
When one trait conflicts with others, it should block the process
of traits rendering no matter they are trying to apply all in one
or one by one.

To fix #141 