### PR TITLE
implement trait.ApplyTo through AppConfig validating webhook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/google/go-cmp v0.4.0
 	github.com/gophercloud/gophercloud v0.6.0 // indirect
-	github.com/json-iterator/go v1.1.10
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1

--- a/pkg/webhook/v1alpha2/applicationconfiguration/helper.go
+++ b/pkg/webhook/v1alpha2/applicationconfiguration/helper.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -16,32 +15,100 @@ import (
 )
 
 const (
-	errUnmarshalTrait        = "cannot unmarshal trait"
-	errFmtGetTraitDefinition = "cannot find trait definition %q %q %q"
+	errFmtGetComponent          = "cannot get component %q"
+	errFmtGetTraitDefinition    = "cannot get trait definition in component %q"
+	errFmtUnmarshalWorkload     = "cannot unmarshal workload of component %q"
+	errFmtUnmarshalTrait        = "cannot unmarshal trait of component %q"
+	errFmtGetWorkloadDefinition = "cannot get workload definition of component %q"
 )
 
-// checkComponentVersionEnabled check whethter a component is versioning mechanism enabled
-func checkComponentVersionEnabled(ctx context.Context, client client.Reader, dm discoverymapper.DiscoveryMapper,
-	acc *v1alpha2.ApplicationConfigurationComponent) (bool, error) {
-	if acc.RevisionName != "" {
-		return true, nil
+// ValidatingAppConfig is used for validating ApplicationConfiguration
+type ValidatingAppConfig struct {
+	appConfig       v1alpha2.ApplicationConfiguration
+	validatingComps []ValidatingComponent
+}
+
+// ValidatingComponent is used for validatiing ApplicationConfigurationComponent
+type ValidatingComponent struct {
+	appConfigComponent v1alpha2.ApplicationConfigurationComponent
+
+	// below data is convenient for validation
+	compName           string
+	component          v1alpha2.Component
+	workloadDefinition v1alpha2.WorkloadDefinition
+	workloadContent    unstructured.Unstructured
+	validatingTraits   []ValidatingTrait
+}
+
+// ValidatingTrait is used for validating Trait
+type ValidatingTrait struct {
+	componentTrait v1alpha2.ComponentTrait
+
+	// below data is convenient for validation
+	traitDefinition v1alpha2.TraitDefinition
+	traitContent    unstructured.Unstructured
+}
+
+// PrepareForValidation prepares data for validations to avoiding repetitive GET/unmarshal operations
+func (v *ValidatingAppConfig) PrepareForValidation(ctx context.Context, c client.Reader, dm discoverymapper.DiscoveryMapper, ac *v1alpha2.ApplicationConfiguration) error {
+	v.appConfig = *ac
+	v.validatingComps = make([]ValidatingComponent, 0, len(ac.Spec.Components))
+	for _, acc := range ac.Spec.Components {
+		tmp := ValidatingComponent{}
+		tmp.appConfigComponent = acc
+
+		if acc.ComponentName != "" {
+			tmp.compName = acc.ComponentName
+		} else {
+			tmp.compName = acc.RevisionName
+		}
+		comp, _, err := util.GetComponent(ctx, c, acc, ac.Namespace)
+		if err != nil {
+			return errors.Wrapf(err, errFmtGetComponent, tmp.compName)
+		}
+		tmp.component = *comp
+
+		// get worload content from raw
+		var wlContentObject map[string]interface{}
+		if err := json.Unmarshal(comp.Spec.Workload.Raw, &wlContentObject); err != nil {
+			return errors.Wrapf(err, errFmtUnmarshalWorkload, tmp.compName)
+		}
+		wl := unstructured.Unstructured{
+			Object: wlContentObject,
+		}
+		tmp.workloadContent = wl
+
+		// get workload definition
+		wlDef, err := util.FetchWorkloadDefinition(ctx, c, dm, &wl)
+		if err != nil {
+			return errors.Wrapf(err, errFmtGetWorkloadDefinition, tmp.compName)
+		}
+		tmp.workloadDefinition = *wlDef
+
+		tmp.validatingTraits = make([]ValidatingTrait, 0, len(acc.Traits))
+		for _, t := range acc.Traits {
+			tmpT := ValidatingTrait{}
+			tmpT.componentTrait = t
+			// get trait content from raw
+			var tContentObject map[string]interface{}
+			if err := json.Unmarshal(t.Trait.Raw, &tContentObject); err != nil {
+				return errors.Wrapf(err, errFmtUnmarshalTrait, tmp.compName)
+			}
+			tContent := unstructured.Unstructured{
+				Object: tContentObject,
+			}
+			// get trait definition
+			tDef, err := util.FetchTraitDefinition(ctx, c, dm, &tContent)
+			if err != nil {
+				return errors.Wrapf(err, errFmtGetTraitDefinition, tmp.compName)
+			}
+			tmpT.traitContent = tContent
+			tmpT.traitDefinition = *tDef
+			tmp.validatingTraits = append(tmp.validatingTraits, tmpT)
+		}
+		v.validatingComps = append(v.validatingComps, tmp)
 	}
-	for _, ct := range acc.Traits {
-		ut := &unstructured.Unstructured{}
-		if err := json.Unmarshal(ct.Trait.Raw, ut); err != nil {
-			return false, errors.Wrap(err, errUnmarshalTrait)
-		}
-		td, err := util.FetchTraitDefinition(ctx, client, dm, ut)
-		if err != nil && !apierrors.IsNotFound(err) {
-			return false, errors.Wrapf(err, errFmtGetTraitDefinition, ut.GetAPIVersion(), ut.GetKind(), ut.GetName())
-		}
-		if td.Spec.RevisionEnabled {
-			// if any traitDefinition's RevisionEnabled is true
-			// then the component is versioning enabled
-			return true, nil
-		}
-	}
-	return false, nil
+	return nil
 }
 
 // checkParams will check whether exist parameter assigning value to workload name

--- a/pkg/webhook/v1alpha2/applicationconfiguration/helper_test.go
+++ b/pkg/webhook/v1alpha2/applicationconfiguration/helper_test.go
@@ -1,115 +1,15 @@
 package applicationconfiguration
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
-	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/stretchr/testify/assert"
 
-	json "github.com/json-iterator/go"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/crossplane/oam-kubernetes-runtime/apis/core/v1alpha2"
-	"github.com/crossplane/oam-kubernetes-runtime/pkg/oam/mock"
 )
-
-func TestCheckComponentVersionEnabled(t *testing.T) {
-	ctx := context.Background()
-	mockClient := test.NewMockClient()
-	traitRevisionEnabled, _ := json.Marshal(v1alpha2.ManualScalerTrait{
-		TypeMeta: v1.TypeMeta{
-			Kind:       "ManualScalerTrait",
-			APIVersion: "core.oam.dev",
-		},
-	})
-
-	tests := []struct {
-		caseName   string
-		mockGetFun test.MockGetFn
-		acc        v1alpha2.ApplicationConfigurationComponent
-		result     bool
-	}{
-		{
-			caseName: "Versioning Disabled",
-			acc: v1alpha2.ApplicationConfigurationComponent{
-				ComponentName: "compName",
-			},
-			result: false,
-		},
-		{
-			caseName: "Versioning Enabled With RevisionName",
-			acc: v1alpha2.ApplicationConfigurationComponent{
-				RevisionName: "revisionName",
-			},
-			result: true,
-		},
-		{
-			caseName: "Versioning Enabled With RevisionEnabled Trait",
-			mockGetFun: func(_ context.Context, _ types.NamespacedName, obj runtime.Object) error {
-				if o, ok := obj.(*v1alpha2.TraitDefinition); ok {
-					*o = v1alpha2.TraitDefinition{
-						Spec: v1alpha2.TraitDefinitionSpec{
-							RevisionEnabled: true,
-						},
-					}
-					return nil
-				}
-				return nil
-			},
-			acc: v1alpha2.ApplicationConfigurationComponent{
-				ComponentName: "compName",
-				Traits: []v1alpha2.ComponentTrait{
-					{
-						Trait: runtime.RawExtension{
-							Raw: traitRevisionEnabled,
-						},
-					},
-				},
-			},
-			result: true,
-		},
-		{
-			caseName: "Unmarshal error occurs",
-			mockGetFun: func(_ context.Context, _ types.NamespacedName, obj runtime.Object) error {
-				if o, ok := obj.(*v1alpha2.TraitDefinition); ok {
-					*o = v1alpha2.TraitDefinition{
-						Spec: v1alpha2.TraitDefinitionSpec{
-							RevisionEnabled: true,
-						},
-					}
-					return nil
-				}
-				return nil
-			},
-			acc: v1alpha2.ApplicationConfigurationComponent{
-				ComponentName: "compName",
-				Traits: []v1alpha2.ComponentTrait{
-					{
-						Trait: runtime.RawExtension{
-							Raw: nil,
-						},
-					},
-				},
-			},
-			result: false,
-		},
-	}
-	mapper := mock.NewMockDiscoveryMapper()
-
-	for _, tv := range tests {
-		func(t *testing.T) {
-			mockClient.MockGet = tv.mockGetFun
-			result, _ := checkComponentVersionEnabled(ctx, mockClient, mapper, &tv.acc)
-			assert.Equal(t, tv.result, result, fmt.Sprintf("Test case: %q", tv.caseName))
-		}(t)
-	}
-
-}
 
 func TestCheckParams(t *testing.T) {
 	wlNameValue := "wlName"


### PR DESCRIPTION
fix #50 & fix #14 
- implement trait.ApplyTo through AppConfig validating webhook
trait.ApplyTo can specify appliable workload in 3 formats: workloadType, workload DefinitionRef name, API Group.  
e.g., ApplyTo: []string{`autoscaler`, `manuscalers.core.oam.dev`,`standard.oam.dev`}
- refactor appConfig validating webhook 
to avoid repetitive GET/unmarshal operations in multiple validation funcs, use a new `ValidatingAppConfig` typed struct to prepare all data before validation
- fix unit tests

Signed-off-by: roy wang <seiwy2010@gmail.com>