### PR TITLE
Add support for ppc64le

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,0 +1,27 @@
+# Build the manager binary
+FROM golang:1.13 as builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY apis/ apis/
+COPY pkg/ pkg/
+COPY cmd/oam-kubernetes-runtime/main.go main.go
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le GO111MODULE=on go build -a -o controller main.go
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot-ppc64le
+WORKDIR /
+COPY --from=builder /workspace/controller .
+USER nonroot:nonroot
+
+ENTRYPOINT ["/controller"]

--- a/images/oam-kubernetes-runtime/Makefile
+++ b/images/oam-kubernetes-runtime/Makefile
@@ -4,6 +4,10 @@
 PLATFORMS := linux_amd64 linux_arm64
 include ../../build/makelib/common.mk
 
+ifeq ($(ARCH),ppc64le)
+       BUILD_ARGS += -f $(IMAGE_TEMP_DIR)/Dockerfile.ppc64le
+endif
+
 # ====================================================================================
 #  Options
 IMAGE = $(BUILD_REGISTRY)/oam-kubernetes-runtime-$(ARCH)


### PR DESCRIPTION
This commit in combination with changes from the following
pull requests on submodule "upbound/build" add support for
build on ppc64le:
https://github.com/upbound/build/pull/134
https://github.com/upbound/build/pull/135

Signed-off-by: Amit Sadaphule <amits2@us.ibm.com>