### PR TITLE
fix contorller: check the number of workloads before applying workloads

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters-settings:
 
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 15
+    min-complexity: 17
 
   maligned:
     # print struct with more effective memory layout or not, false by default

--- a/pkg/controller/v1alpha2/applicationconfiguration/apply.go
+++ b/pkg/controller/v1alpha2/applicationconfiguration/apply.go
@@ -100,6 +100,9 @@ type workloads struct {
 }
 
 func (a *workloads) Apply(ctx context.Context, status []v1alpha2.WorkloadStatus, w []Workload, ao ...resource.ApplyOption) error {
+	if len(w) == 0 {
+		return errors.New("The number of workloads in appConfig is 0")
+	}
 	// they are all in the same namespace
 	var namespace = w[0].Workload.GetNamespace()
 	for _, wl := range w {


### PR DESCRIPTION
fix https://github.com/crossplane/oam-kubernetes-runtime/issues/327

check the number of workloads before applying workloads, 
fix the problem that the array is out of bounds.